### PR TITLE
fix(integrations): make `defineLayout` auto-importable

### DIFF
--- a/packages/vue/src/integrations/unplugin-vue-components.ts
+++ b/packages/vue/src/integrations/unplugin-vue-components.ts
@@ -12,7 +12,7 @@ export const HybridlyImports = {
 		'useForm',
 		'useHistoryState',
 		'usePaginator',
-		'useLayout',
+		'defineLayout',
 		'route',
 	],
 	'hybridly': [


### PR DESCRIPTION
This is a follow up for the https://github.com/hybridly/hybridly/commit/836d72a