### PR TITLE
docs: fix homepage typo

### DIFF
--- a/docs/.vitepress/theme/components/marketing.vue
+++ b/docs/.vitepress/theme/components/marketing.vue
@@ -19,7 +19,7 @@ const features: Feature[] = [
 	},
 	{
 		title: 'Routes',
-		description: 'Define your routes server-side like you\'re used to, Hybridly takes care of gererating types for them.',
+		description: 'Define your routes server-side like you\'re used to, Hybridly takes care of generating types for them.',
 		url: '/guide/routing',
 	},
 	{


### PR DESCRIPTION
This PR:

- [x] Fixes a small typo on the documentation's home page.