### PR TITLE
docs: fix router link page typos

### DIFF
--- a/docs/api/components/router-link.md
+++ b/docs/api/components/router-link.md
@@ -2,7 +2,7 @@
 
 This built-in component can be used to replace [anchor tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) to navigate from a hybrid page to another.
 
-This component is a wrapper around Vue's [`<Component>` ](https://vuejs.org/api/built-in-special-elements.html#component). By default, it creates anchors elements but intercept their click handlers to make [hybrid navigations](../../guide/navigation.md).
+This component is a wrapper around Vue's [`<Component>` ](https://vuejs.org/api/built-in-special-elements.html#component). By default, it creates anchors elements but intercepts their click handlers to make [hybrid navigations](../../guide/navigation.md).
 
 ## `href`
 
@@ -25,7 +25,7 @@ Similar to the `<a>` tag, accepts the hyperlink to navigate to. If this doesn't 
 
 - **Type**: boolean
 
-When set to `true`, disables the custom click handler. This must be used when navigating to external websites or non-hybrid pages — otherwise, the a hybrid request will be made and will result into an error.
+When set to `true`, disables the custom click handler. This must be used when navigating to external websites or non-hybrid pages — otherwise, a hybrid request will be made and will result into an error.
 
 ### Usage
 


### PR DESCRIPTION
This PR:

- [x] Fixes two minor typos in the [RouterLink](https://hybridly.dev/api/components/router-link.html) documentation page.