### PR TITLE
docs: fix `Suggest changes to this page` link

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -50,7 +50,7 @@ export default async() => defineConfig({
 		],
 
 		editLink: {
-			pattern: `${github}/edit/main/docs/:path`,
+			pattern: `${github}/edit/0.x/docs/:path`,
 			text: 'Suggest changes to this page',
 		},
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path'
 import { readFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
 import { defineConfig } from 'vitepress'
 import Unocss from 'unocss/vite'
 import highlighter from './shiki-tags/highlighter'
@@ -13,6 +14,7 @@ const discord = 'https://discord.gg/uZ8eC7kRFV'
 const github = 'https://github.com/hybridly/hybridly'
 
 const { version } = JSON.parse(readFileSync(resolve('package.json'), { encoding: 'utf-8' }))
+const branch = execSync('git rev-parse --abbrev-ref HEAD')
 
 export default async() => defineConfig({
 	title,
@@ -50,7 +52,7 @@ export default async() => defineConfig({
 		],
 
 		editLink: {
-			pattern: `${github}/edit/0.x/docs/:path`,
+			pattern: `${github}/edit/${branch}/docs/:path`,
 			text: 'Suggest changes to this page',
 		},
 


### PR DESCRIPTION
The `Suggest changes to this page` link that can be found at the bottom of all documentation pages incorrectly points to the `main` branch, which leads to a 404 because the default branch is `0.x`.

<img width="736" alt="Screenshot 2022-10-23 at 17 47 53" src="https://user-images.githubusercontent.com/649677/197401969-af2d01b3-611d-4c43-9377-6aab69a00091.png">

This PR: 

- [x] Updates the `editLink.pattern` option to rename the branch from `main` to `0.x`.