### PR TITLE
Correct typo

### DIFF
--- a/docs/.vitepress/theme/components/marketing.vue
+++ b/docs/.vitepress/theme/components/marketing.vue
@@ -27,7 +27,7 @@ const features: Feature[] = [
 	},
 	{
 		icon: 'i-mdi:magnify',
-		title: 'Vue DevToools',
+		title: 'Vue DevTools',
 		description: 'Integrates with Vue DevTools for painless property inspection and debugging.',
 		url: '/guide/devtools',
 	},


### PR DESCRIPTION
Corrects the text from "DevToools" to "DevTools" on the marketing page.