### PR TITLE
fix(types): make `Paginator` properties non-optional

### DIFF
--- a/packages/vue/src/composables/paginator.ts
+++ b/packages/vue/src/composables/paginator.ts
@@ -8,8 +8,8 @@ declare global {
 	 */
 	interface Paginator<T = any> {
 		data: T[]
-		meta?: PaginatorMeta
-		links?: PaginatorLink[]
+		meta: PaginatorMeta
+		links: PaginatorLink[]
 	}
 
 	/**


### PR DESCRIPTION
From what I learned the Laravel's paginator always return `meta` and `links`, so I think they should be required, otherwise we have to use custom interfaces or inline types such as :
```ts
fields: {
     page: $props.posts.meta?.current_page as number,
},
```
Wasn't sure if this would be an opinionated PR, but did it anyway.