### PR TITLE
feat(assertHybridProperties): add null assertion support

### DIFF
--- a/packages/laravel/src/Testing/Assertable.php
+++ b/packages/laravel/src/Testing/Assertable.php
@@ -114,6 +114,13 @@ class Assertable extends AssertableJson
                 continue;
             }
 
+            // ['property_name' => null] -> assert that it's a null value
+            if (\is_string($key) && \is_null($value)) {
+                $this->where($scope . '.' . $key, null);
+
+                continue;
+            }
+
             throw new \LogicException("Unknown syntax [{$key} => {$value}]");
         }
 

--- a/tests/src/Laravel/Testing/TestResponseMacrosTest.php
+++ b/tests/src/Laravel/Testing/TestResponseMacrosTest.php
@@ -57,6 +57,7 @@ test('the `assertHybridProperties` method asserts the properties using the given
             'owo' => 'hewwo',
             'ewe' => 'world',
         ],
+        'zoo' => null,
     ])->assertHybridProperties([
         'foo', // asserts it exists
         'foo' => 'bar', // asserts it has the given value
@@ -65,6 +66,7 @@ test('the `assertHybridProperties` method asserts the properties using the given
         'uwu.ewe' => 'world', // asserts it has the given value
         'baz' => 3, // asserts it has the given count
         'uwu' => fn (Assertable $uwu) => $uwu->hasAll(['owo', 'ewe']), // asserts using callback
+        'zoo' => null, // assert that value is null
     ]);
 });
 


### PR DESCRIPTION
This PR adds support to assert null values for `assertHybridProperties` helper.

```php
->assertHybridProperties([
    'foo' => null, // assert that value is null
]);
```