### PR TITLE
feat(testing): add bool assertion support to `assertHybridProperties`

### DIFF
--- a/packages/laravel/src/Testing/Assertable.php
+++ b/packages/laravel/src/Testing/Assertable.php
@@ -130,6 +130,13 @@ class Assertable extends AssertableJson
                 continue;
             }
 
+            // ['property_name' => true] -> assert that it's a bool value
+            if (\is_string($key) && \is_bool($value)) {
+                $this->where($scope . '.' . $key, $value);
+
+                continue;
+            }
+
             throw new \LogicException("Unknown syntax [{$key} => {$value}]");
         }
 

--- a/tests/src/Laravel/Testing/TestResponseMacrosTest.php
+++ b/tests/src/Laravel/Testing/TestResponseMacrosTest.php
@@ -58,6 +58,7 @@ test('the `assertHybridProperties` method asserts the properties using the given
             'ewe' => 'world',
         ],
         'zoo' => null,
+        'shoo' => true,
     ])->assertHybridProperties([
         'foo', // asserts it exists
         'foo' => 'bar', // asserts it has the given value
@@ -69,6 +70,7 @@ test('the `assertHybridProperties` method asserts the properties using the given
         'foo' => fn ($foo) => expect($foo)->toBe('bar'), // asserts using callback
         'uwu.owo' => fn ($owo) => expect($owo)->toBe('hewwo'), // asserts using callback and dot notation
         'zoo' => null, // assert that value is null
+        'shoo' => true, // assert that value is true
     ]);
 });
 

--- a/tests/src/Laravel/Testing/TestResponseMacrosTest.php
+++ b/tests/src/Laravel/Testing/TestResponseMacrosTest.php
@@ -58,7 +58,8 @@ test('the `assertHybridProperties` method asserts the properties using the given
             'ewe' => 'world',
         ],
         'zoo' => null,
-        'shoo' => true,
+        'true' => true,
+        'false' => false,
     ])->assertHybridProperties([
         'foo', // asserts it exists
         'foo' => 'bar', // asserts it has the given value
@@ -70,7 +71,8 @@ test('the `assertHybridProperties` method asserts the properties using the given
         'foo' => fn ($foo) => expect($foo)->toBe('bar'), // asserts using callback
         'uwu.owo' => fn ($owo) => expect($owo)->toBe('hewwo'), // asserts using callback and dot notation
         'zoo' => null, // assert that value is null
-        'shoo' => true, // assert that value is true
+        'true' => true, // assert that value is true
+        'false' => false, // assert that value is false
     ]);
 });
 


### PR DESCRIPTION
This PR adds support to assert boolean values for assertHybridProperties helper.
```php
->assertHybridProperties([
    'foo' => true, // assert that value is true
]);
```