### PR TITLE
feat(testing): add numeric assertion support to `assertHybridProperties`

### DIFF
--- a/packages/laravel/src/Testing/Assertable.php
+++ b/packages/laravel/src/Testing/Assertable.php
@@ -95,7 +95,13 @@ class Assertable extends AssertableJson
 
             // ['property_name' => 10] -> assert that it exists and has the given count
             if (\is_string($key) && \is_int($value)) {
-                $this->has($scope . '.' . $key, length: $value);
+                // If the value is countable or iterable, assert that it has the given count.
+                // If not, assert its exact value
+                if (is_countable(data_get($this->properties, $key)) || is_iterable(data_get($this->properties, $key))) {
+                    $this->has($scope . '.' . $key, $value);
+                } else {
+                    $this->where($scope . '.' . $key, $value);
+                }
 
                 continue;
             }

--- a/tests/src/Laravel/Testing/TestResponseMacrosTest.php
+++ b/tests/src/Laravel/Testing/TestResponseMacrosTest.php
@@ -53,6 +53,7 @@ test('the `assertHybridProperties` method asserts the properties using the given
     makeHybridMockRequest(properties: [
         'foo' => 'bar',
         'baz' => [1, 2, 3],
+        'five' => 5,
         'uwu' => [
             'owo' => 'hewwo',
             'ewe' => 'world',
@@ -65,6 +66,7 @@ test('the `assertHybridProperties` method asserts the properties using the given
         'uwu.owo' => 'hewwo', // asserts it has the given value
         'uwu.ewe' => 'world', // asserts it has the given value
         'baz' => 3, // asserts it has the given count
+        'five' => 5, // asserts it has the given value
         'uwu' => fn (Assertable $assert) => $assert->hasAll(['owo', 'ewe']), // asserts using callback and typehinted parameter
         'foo' => fn ($foo) => expect($foo)->toBe('bar'), // asserts using callback
         'uwu.owo' => fn ($owo) => expect($owo)->toBe('hewwo'), // asserts using callback and dot notation


### PR DESCRIPTION
This PR adds support to assert numeric values for assertHybridProperties helper.
```php
// 'foo' => 5
->assertHybridProperties([
    'foo' => 5, // assert that value is 5
]);

// 'foo' => [1, 2]
->assertHybridProperties([
    'foo' => 2, // assert that the given count is 2
]);
```