### PR TITLE
feat: make Hybridly conditionable

### DIFF
--- a/packages/laravel/src/Concerns/HasSharedProperties.php
+++ b/packages/laravel/src/Concerns/HasSharedProperties.php
@@ -26,12 +26,24 @@ trait HasSharedProperties
     }
 
     /**
-     * Shares data to every response if the condition is true.
+     * Only apply the chain calls if the condition is true.
      */
-    public function shareWhen(bool|\Closure $condition, string|array|Arrayable $key, mixed $value = null): static
+    public function when(bool|\Closure $condition): static
     {
         if ($condition instanceof \Closure ? $condition($this) : $condition) {
-            $this->share($key, $value);
+            return $this;
+        }
+
+        return new static();
+    }
+
+    /**
+     * Unless the condition is true, apply the chain calls.
+     */
+    public function unless(bool|\Closure $condition): static
+    {
+        if ($condition instanceof \Closure ? $condition($this) : $condition) {
+            return new static();
         }
 
         return $this;

--- a/packages/laravel/src/Concerns/HasSharedProperties.php
+++ b/packages/laravel/src/Concerns/HasSharedProperties.php
@@ -4,9 +4,12 @@ namespace Hybridly\Concerns;
 
 use Hybridly\Support\Arr;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Traits\Conditionable;
 
 trait HasSharedProperties
 {
+    use Conditionable;
+
     protected array $sharedProperties = [];
 
     /**
@@ -20,30 +23,6 @@ trait HasSharedProperties
             $this->sharedProperties = array_merge($this->sharedProperties, $key->toArray());
         } else {
             Arr::set($this->sharedProperties, $key, value($value));
-        }
-
-        return $this;
-    }
-
-    /**
-     * Only apply the chain calls if the condition is true.
-     */
-    public function when(bool|\Closure $condition): static
-    {
-        if ($condition instanceof \Closure ? $condition($this) : $condition) {
-            return $this;
-        }
-
-        return new static();
-    }
-
-    /**
-     * Unless the condition is true, apply the chain calls.
-     */
-    public function unless(bool|\Closure $condition): static
-    {
-        if ($condition instanceof \Closure ? $condition($this) : $condition) {
-            return new static();
         }
 
         return $this;

--- a/packages/laravel/src/Concerns/HasSharedProperties.php
+++ b/packages/laravel/src/Concerns/HasSharedProperties.php
@@ -26,6 +26,18 @@ trait HasSharedProperties
     }
 
     /**
+     * Shares data to every response if the condition is true.
+     */
+    public function shareWhen(bool|\Closure $condition, string|array|Arrayable $key, mixed $value = null): static
+    {
+        if ($condition) {
+            $this->share($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
      * Gets data being shared to every response.
      */
     public function shared(string $key = null, mixed $default = null): mixed

--- a/packages/laravel/src/Concerns/HasSharedProperties.php
+++ b/packages/laravel/src/Concerns/HasSharedProperties.php
@@ -4,12 +4,9 @@ namespace Hybridly\Concerns;
 
 use Hybridly\Support\Arr;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Traits\Conditionable;
 
 trait HasSharedProperties
 {
-    use Conditionable;
-
     protected array $sharedProperties = [];
 
     /**

--- a/packages/laravel/src/Concerns/HasSharedProperties.php
+++ b/packages/laravel/src/Concerns/HasSharedProperties.php
@@ -30,7 +30,7 @@ trait HasSharedProperties
      */
     public function shareWhen(bool|\Closure $condition, string|array|Arrayable $key, mixed $value = null): static
     {
-        if ($condition) {
+        if ($condition === true || ($condition instanceof \Closure && $condition() === true)) {
             $this->share($key, $value);
         }
 

--- a/packages/laravel/src/Concerns/HasSharedProperties.php
+++ b/packages/laravel/src/Concerns/HasSharedProperties.php
@@ -30,7 +30,7 @@ trait HasSharedProperties
      */
     public function shareWhen(bool|\Closure $condition, string|array|Arrayable $key, mixed $value = null): static
     {
-        if ($condition === true || ($condition instanceof \Closure && $condition() === true)) {
+        if ($condition instanceof \Closure ? $condition($this) : $condition) {
             $this->share($key, $value);
         }
 

--- a/packages/laravel/src/Hybridly.php
+++ b/packages/laravel/src/Hybridly.php
@@ -6,6 +6,7 @@ use Hybridly\Support\Partial;
 use Hybridly\View\Factory;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Request;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Spatie\LaravelData\Contracts\DataObject;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -17,6 +18,7 @@ class Hybridly
     use Concerns\HasRootView;
     use Concerns\HasSharedProperties;
     use Concerns\HasVersion;
+    use Conditionable;
     use Macroable;
 
     public const HYBRIDLY_HEADER = 'x-hybrid';


### PR DESCRIPTION
This PR is to add a `when()` and `unless()` helpers, so sharing data conditionally becomes easier.

Before:
```php
if( $condition ){
    hybridly()->share('foo', 'bar');
}
```
After:
```php
hybridly()->when($condition)->share('foo', 'bar');

// or:

hybridly()->unless($condition)->share('foo', 'bar');
```