### PR TITLE
feat(routing): support bindings in route domain

### DIFF
--- a/packages/core/src/routing/route.ts
+++ b/packages/core/src/routing/route.ts
@@ -35,7 +35,7 @@ function getRouteTransformable(routeName: string, routeParameters?: any, shouldT
 	const definition = getRouteDefinition(routeName)
 	const parameters = routeParameters || {}
 	const missing: string[] = Object.keys(parameters)
-	const path = definition.uri.replace(/{([^}?]+)\??}/g, (match: string, parameterName: string) => {
+	const replaceParameter = (match: string, parameterName: string) => {
 		const optional = /\?}$/.test(match)
 		const value = (() => {
 			const value = parameters[parameterName]
@@ -78,7 +78,10 @@ function getRouteTransformable(routeName: string, routeParameters?: any, shouldT
 		}
 
 		throw new MissingRouteParameter(parameterName, routeName)
-	})
+	}
+
+	const path = definition.uri.replace(/{([^}?]+)\??}/g, replaceParameter)
+	const domain = definition.domain?.replace(/{([^}?]+)\??}/g, replaceParameter)
 
 	// Filters from `parameters` the values from `missing`
 	// and returns a new object with the remaining values.
@@ -90,6 +93,7 @@ function getRouteTransformable(routeName: string, routeParameters?: any, shouldT
 		}), {})
 
 	return {
+		...domain && { hostname: domain },
 		pathname: path,
 		search: qs.stringify(remaining, {
 			encodeValuesOnly: true,

--- a/packages/core/test/routing/fixtures/routing.json
+++ b/packages/core/test/routing/fixtures/routing.json
@@ -43,6 +43,14 @@
 			"bindings": [],
 			"wheres": []
 		},
+		"subdomain": {
+			"domain": "{subdomain}.bluebird.test",
+			"method": ["GET", "HEAD"],
+			"uri": "",
+			"name": "subdomain",
+			"bindings": { "subdomain": "subdomain" },
+			"wheres": []
+		},
 		"chirp.store": {
 			"domain": null,
 			"method": ["POST"],

--- a/packages/core/test/routing/route.test.ts
+++ b/packages/core/test/routing/route.test.ts
@@ -19,6 +19,7 @@ describe('an url can be generated from a route name', () => {
 	test('with required parameter', () => {
 		expect(route('chirp.show', { chirp: 10 })).toBe('https://bluebird.test/chirps/10')
 		expect(route('chirp.show', { chirp: 10 }, false)).toBe('/chirps/10')
+		expect(route('subdomain', { subdomain: 'demo' })).toBe('https://demo.bluebird.test')
 	})
 
 	test('throws when required parameter is missing', () => {


### PR DESCRIPTION
This PR:

- [x] Adds support for replacing route bindings in the domain of a route.

---

### Background

Currently, the client side `route` helper only replaces existing bindings in the route's URI. 

Assuming that you define the following route in Laravel.

```php
Route::get('/', fn() => hybridly('home))
    ->domain('{subdomain}.bluebird.test')
    ->name('home')
```

And then use it in the frontend like so.

```ts
const home = route('home', { subdomain: 'demo' })
```

The resulting URL will be `https://{subdomain}.bluebird.test?subdomain=demo` while we'd expect it to be `https://demo.bluebird.test`
