### PR TITLE
docs(dialogs): add missing title prop to dialog example

### DIFF
--- a/docs/guide/dialogs.md
+++ b/docs/guide/dialogs.md
@@ -34,6 +34,10 @@ defineProps<{
 import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue'
 
 const { show, close, unmount } = useDialog() // [!code focus]
+
+defineProps<{
+  title?: string
+}>()
 </script>
 
 <template>


### PR DESCRIPTION
The base modal example is missing the `title` prop. The PR adds that.