### PR TITLE
feat(testing): dialog testing helpers

### DIFF
--- a/packages/laravel/src/Testing/Assertable.php
+++ b/packages/laravel/src/Testing/Assertable.php
@@ -58,7 +58,6 @@ class Assertable extends AssertableJson
 
     public function dialog(array $properties = null, string $view = null, string $baseUrl = null, string $redirectUrl = null): self
     {
-        ray($this);
         PHPUnit::assertNotNull($this->dialog, 'There is no dialog.');
 
         if ($baseUrl) {

--- a/packages/laravel/src/Testing/Assertable.php
+++ b/packages/laravel/src/Testing/Assertable.php
@@ -58,6 +58,7 @@ class Assertable extends AssertableJson
 
     public function dialog(array $properties = null, string $view = null, string $baseUrl = null, string $redirectUrl = null): self
     {
+        ray($this->dialog);
         PHPUnit::assertNotNull($this->dialog, 'There is no dialog.');
 
         if ($baseUrl) {

--- a/packages/laravel/src/Testing/TestResponseMacros.php
+++ b/packages/laravel/src/Testing/TestResponseMacros.php
@@ -146,11 +146,11 @@ class TestResponseMacros
     /**
      * Asserts that the hybrid response's dialog view is the expected value.
      */
-    public function assertHybridDialogView(): Closure
+    public function assertHybridDialog(): Closure
     {
-        return function (string $dialogView, ?string $baseUrl = null): TestResponse {
+        return function (array $properties = null, string $view = null, string $baseUrl = null, string $redirectUrl = null): TestResponse {
             /** @var TestResponse $this */
-            Assertable::fromTestResponse($this)->dialogView($dialogView, $baseUrl);
+            Assertable::fromTestResponse($this)->dialog($properties, $view, $baseUrl, $redirectUrl);
 
             return $this;
         };

--- a/packages/laravel/src/Testing/TestResponseMacros.php
+++ b/packages/laravel/src/Testing/TestResponseMacros.php
@@ -144,6 +144,19 @@ class TestResponseMacros
     }
 
     /**
+     * Asserts that the hybrid response's dialog view is the expected value.
+     */
+    public function assertHybridDialogView(): Closure
+    {
+        return function (string $dialogView, ?string $baseUrl = null): TestResponse {
+            /** @var TestResponse $this */
+            Assertable::fromTestResponse($this)->dialogView($dialogView, $baseUrl);
+
+            return $this;
+        };
+    }
+
+    /**
      * Asserts that the hybrid response's version is the expected value.
      */
     public function assertHybridVersion(): Closure

--- a/packages/laravel/src/View/Factory.php
+++ b/packages/laravel/src/View/Factory.php
@@ -155,7 +155,6 @@ class Factory implements HybridResponse
 
     protected function renderDialog(Request $request, Payload $payload)
     {
-        // TODO the context thing
         $kernel = app()->make(Kernel::class);
         $url = $payload->dialog->redirectUrl;
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -39,16 +39,10 @@ function makeMockRequest(mixed $response, string $url = '/mock-url'): TestRespon
     return get($url);
 }
 
-function makeHybridMockRequest(string $component = 'test', mixed $properties = [], string $url = '/hybrid-mock-url', \Closure $tap = null): TestResponse
+function makeHybridMockRequest(string $component = 'test', mixed $properties = [], string $url = '/hybrid-mock-url'): TestResponse
 {
-    $response = hybridly($component, $properties);
-
-    if (is_callable($tap)) {
-        $response = $tap($response);
-    }
-
     return makeMockRequest(
-        response: $response,
+        response: hybridly($component, $properties),
         url: $url,
     );
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -39,10 +39,16 @@ function makeMockRequest(mixed $response, string $url = '/mock-url'): TestRespon
     return get($url);
 }
 
-function makeHybridMockRequest(string $component = 'test', mixed $properties = [], string $url = '/hybrid-mock-url'): TestResponse
+function makeHybridMockRequest(string $component = 'test', mixed $properties = [], string $url = '/hybrid-mock-url', \Closure $tap = null): TestResponse
 {
+    $response = hybridly($component, $properties);
+
+    if (is_callable($tap)) {
+        $response = $tap($response);
+    }
+
     return makeMockRequest(
-        response: hybridly($component, $properties),
+        response: $response,
         url: $url,
     );
 }

--- a/tests/src/Laravel/Testing/TestResponseMacrosTest.php
+++ b/tests/src/Laravel/Testing/TestResponseMacrosTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Hybridly\Testing\Assertable;
+use Hybridly\View\Factory;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Testing\TestResponse;
 
 test('the `assertHybrid` method runs its callback', function () {
@@ -12,6 +14,26 @@ test('the `assertHybrid` method runs its callback', function () {
     });
 
     expect($success)->toBeTrue();
+});
+
+test('the `assertDialog` method asserts dialog view component, base url and properties', function () {
+    Route::get('/test/page', fn () => hybridly('test.page'))->name('test.page');
+    Route::get('/test/dialog', fn () => hybridly('test.dialog', ['foo' => 'bar']))->name('test.dialog');
+
+    makeHybridMockRequest(
+        component: 'test.dialog',
+        url: '/test/dialog',
+        tap: fn (Factory $factory) => $factory->base('test.page'),
+    )
+        ->assertHybridView('test.page')
+        ->assertHybridUrl('http://localhost/test/dialog')
+        ->assertHybridDialog(
+            baseUrl: 'http://localhost/test/page',
+            view: 'test.dialog',
+            properties: [
+                'foo' => 'bar',
+            ],
+        );
 });
 
 test('the `assertNotHybrid` method asserts that non-hybrid responses are non-hybrid', function () {

--- a/tests/src/Laravel/Testing/TestResponseMacrosTest.php
+++ b/tests/src/Laravel/Testing/TestResponseMacrosTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Hybridly\Testing\Assertable;
-use Hybridly\View\Factory;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Testing\TestResponse;
+
+use function Pest\Laravel\get;
 
 test('the `assertHybrid` method runs its callback', function () {
     $success = false;
@@ -16,15 +17,11 @@ test('the `assertHybrid` method runs its callback', function () {
     expect($success)->toBeTrue();
 });
 
-test('the `assertDialog` method asserts dialog view component, base url and properties', function () {
+test('the `assertHybridDialog` method asserts dialog view component & base url & properties', function () {
     Route::get('/test/page', fn () => hybridly('test.page'))->name('test.page');
-    Route::get('/test/dialog', fn () => hybridly('test.dialog', ['foo' => 'bar']))->name('test.dialog');
+    Route::get('/test/dialog', fn () => hybridly('test.dialog', ['foo' => 'bar'])->base('test.page'))->name('test.dialog');
 
-    makeHybridMockRequest(
-        component: 'test.dialog',
-        url: '/test/dialog',
-        tap: fn (Factory $factory) => $factory->base('test.page'),
-    )
+    get('/test/dialog')
         ->assertHybridView('test.page')
         ->assertHybridUrl('http://localhost/test/dialog')
         ->assertHybridDialog(


### PR DESCRIPTION
This PR adds support to assert dialog views.
### Controller method
```php
public function create()
{
    return hybridly('chirps.create')->base('chirps.index');
}
```
### Test helper
First argument would be the dialog view component that should be asserted.
```php
assertHybridDialogView('chirps.create');
```
You can also pass the base url as second argument.
```php
assertHybridDialogView('chirps.create', route('chirps.index'));
```