### PR TITLE
refactor(form): don't clear errors on reset

### DIFF
--- a/packages/vue/src/composables/form.ts
+++ b/packages/vue/src/composables/form.ts
@@ -74,7 +74,6 @@ export function useForm<T extends Fields = Fields>(options: FormOptions<T>) {
 
 		keys.forEach((key) => {
 			Reflect.set(fields, key, safeClone(Reflect.get(initial, key)))
-			clearError(key)
 		})
 	}
 


### PR DESCRIPTION
`form.reset()` is often being used to reset input elements like password inputs, when the request
failed. One example would be Laravel/Jetstream in its various password challenge forms.

With this change we are back to the behavior of inertia and would 1. make a migration easier and 2. lose nearly no DX. This is, because in the event of a successful request form errors are already not present anymore (since it was successful). The only case where `clearErrors()` now has to be called is in cases where
the UI needs to be reset, eg. when closing a modal with a form, which can still be done via the `form.clearErrors()` method.

But as already discussed on discord, I'm open for suggestions.