### PR TITLE
Ideas for authorization utils

### DIFF
--- a/packages/core/src/authorization.ts
+++ b/packages/core/src/authorization.ts
@@ -6,10 +6,22 @@ export interface Authorizable<Authorizations extends Record<string, boolean>> {
  * Checks whether the given data has the authorization for the given action.
  * If the data object has no authorization definition corresponding to the given action, this method will return `false`.
  */
-export function can<
-	Authorizations extends Record<string, boolean>,
-	Data extends Authorizable<Authorizations>,
-	Action extends keyof Data['authorization']
->(resource: Data, action: Action) {
-	return resource.authorization?.[action] ?? false
+function can<
+    Authorizations extends Record<string, boolean>,
+    Data extends Authorizable<Authorizations>,
+    Action extends keyof Data['authorization']
+>(action: Action, resource: Data) {
+    if (resource === undefined) {
+        return useProperty('security.user').value?.authorization?.[action] ?? false
+    }
+
+    return resource.authorization?.[action] ?? false
+}
+
+function cannot<
+    Authorizations extends Record<string, boolean>,
+    Data extends Authorizable<Authorizations>,
+    Action extends keyof Data['authorization']
+>(action: Action, resource: Data) {
+    return ! can(action, resource)
 }


### PR DESCRIPTION
# Draft (be carefull)
This pull request is just a draft of several ideas, so it probably needs improvements on a lot of places.

It contains three potential ideas to improve the `can` util / authorization. I wanna improve the PR based on given feedback.

## Swap arguments (breaking change)
By swapping the arguments of the `can` util it aligns with the `@can` helper of Laravel. In my opinion it also reads better (user can edit X).
So instead of `can($props.chirp, 'edit')` it becomes `can('edit', $props.chirp)`. 

The way I fixed it is a breaking change. There is probably a way to let the first parameter accept both, im not sure if that makes it better.

## Authorization without resource
With this one I need some good feedback. For now I just sketched the idea with using:
```js
return useProperty('security.user').value?.authorization?.[action] ?? false
```

Lets say you write gate within the `AuthServiceProvider` like this:

```php
Gate::define('view-prices', function (User $user) {
    return str_ends_with($user->email, '@example.com');
});
```

And define the authorization on the `UserData`. Like this:
```php
public static array $authorizations = [
    'view-prices',
];
```

Ideally would be you can write `can('view-prices')` instead of `can('view-prices', user)`.
But somewhere we need to define what the "fallback" authorization object would be, which I now hardcoded on 'security.user'. I also wonder if that should be on the user level. Because I think Laravel also allows usage of Gates like this:

```php
Gate::define('view-prices', function (?User $user) {
    $ipAddress = '1.2.3.4';

    return str_ends_with($ipAddress, '.4');
});
```

In this case the gate is not related to an user, so then it should for example be on the `SharedData` level?

## Cannot helper
Just the opposite of `can`, probably we can improve the typescript hinting there.