### PR TITLE
feat(laravel): conditional return type for phpstan

### DIFF
--- a/packages/laravel/src/helpers.php
+++ b/packages/laravel/src/helpers.php
@@ -29,6 +29,8 @@ if (!function_exists('is_partial')) {
 if (!function_exists('hybridly')) {
     /**
      * Gets the hybridly instance or returns a view.
+     *
+     * @phpstan-return ($component is string ? \Hybridly\View\Factory : \Hybridly\Hybridly)
      */
     function hybridly(string $component = null, array|Arrayable|DataObject $properties = []): Hybridly|Factory
     {


### PR DESCRIPTION
This adds a conditional return type annotation [0] for phpstan. With this annotation, projects with phpstan enabled will not see errors anymore when using the hybridly() helper function.

Additionally we only use the phpstan specific annotation, to avoid unnecessary issues with tools like intelephense, which do not yet support conditional types.

This for example fixes:  
<img width="747" alt="image" src="https://user-images.githubusercontent.com/10776964/219615903-33b5ec9a-9fa5-4b2b-8a89-2d9b26253a9f.png">


[0] https://phpstan.org/writing-php-code/phpdoc-types#conditional-return-types