### PR TITLE
fix(i18n): escape `@` for vue-i18n

### DIFF
--- a/packages/laravel/src/Commands/I18nCommand.php
+++ b/packages/laravel/src/Commands/I18nCommand.php
@@ -5,7 +5,6 @@ namespace Hybridly\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
-use Illuminate\Support\Stringable;
 
 /**
  * Generates a JSON file with all translations.

--- a/packages/laravel/src/Commands/I18nCommand.php
+++ b/packages/laravel/src/Commands/I18nCommand.php
@@ -5,6 +5,7 @@ namespace Hybridly\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 
 /**
  * Generates a JSON file with all translations.
@@ -100,7 +101,10 @@ class I18nCommand extends Command
      */
     protected function getTranslationsAsJson(string $lang = null): string
     {
-        return preg_replace('/:(\w+)/', '{${1}}', json_encode($this->getTranslations($lang)));
+        return Str::of(json_encode($this->getTranslations($lang)))
+            ->pipe(fn(Stringable $str) => preg_replace('/:(\w+)/', '{${1}}', $str->toString()))
+            ->pipe(fn(Stringable $str) => preg_replace('/\@/', '{\'@\'}', $str->toString()))
+            ->toString();
     }
 
     /**

--- a/packages/laravel/src/Commands/I18nCommand.php
+++ b/packages/laravel/src/Commands/I18nCommand.php
@@ -102,8 +102,8 @@ class I18nCommand extends Command
     protected function getTranslationsAsJson(string $lang = null): string
     {
         return Str::of(json_encode($this->getTranslations($lang)))
-            ->pipe(fn(Stringable $str) => preg_replace('/:(\w+)/', '{${1}}', $str->toString()))
-            ->pipe(fn(Stringable $str) => preg_replace('/\@/', '{\'@\'}', $str->toString()))
+            ->replaceMatches('/:(\w+)/', '{${1}}')
+            ->replaceMatches('/\@/', '{\'@\'}')
             ->toString();
     }
 

--- a/packages/laravel/src/Commands/I18nCommand.php
+++ b/packages/laravel/src/Commands/I18nCommand.php
@@ -101,7 +101,7 @@ class I18nCommand extends Command
      */
     protected function getTranslationsAsJson(string $lang = null): string
     {
-        return Str::of(json_encode($this->getTranslations($lang)))
+        return str(json_encode($this->getTranslations($lang)))
             ->replaceMatches('/:(\w+)/', '{${1}}')
             ->replaceMatches('/\@/', '{\'@\'}')
             ->toString();


### PR DESCRIPTION
Currently laravel takes @ symbols on translations just normally but @ symbol at vue18n must be wrapped with brackets around it, this should bring support for it by using Str::pipe, so further symbols can also be quickly added.


@see: https://github.com/intlify/vue-i18n-next/issues/118