### PR TITLE
fix(vue): support nullable paths in `useProperty`

### DIFF
--- a/packages/vite/src/integrations/auto-imports.ts
+++ b/packages/vite/src/integrations/auto-imports.ts
@@ -9,7 +9,6 @@ type AutoImportOptions = Parameters<typeof autoimport>[0]
 export const HybridlyImports = {
 	'hybridly/vue': [
 		'useProperty',
-		'useTypedProperty',
 		'useProperties',
 		'useBackForward',
 		'useContext',

--- a/packages/vue/src/composables/property.ts
+++ b/packages/vue/src/composables/property.ts
@@ -31,7 +31,7 @@ export function useProperty<
 ): ComputedRef<[PathValue<T, P>] extends [never] ? Fallback : PathValue<T, P>> {
 	return computed(() => (path as string)
 		.split('.')
-		.reduce((o: any, i: string) => o[i], state.context.value?.view.properties) as any
+		.reduce((o: any, i: string) => o?.[i], state.context.value?.view.properties) as any
 		?? fallback,
 	)
 }

--- a/packages/vue/src/composables/property.ts
+++ b/packages/vue/src/composables/property.ts
@@ -41,10 +41,10 @@ export function useProperty<
 
 type PathImpl<T, K extends keyof T> =
 	K extends string
-		? T[K] extends Record<string, any>
-			? T[K] extends ArrayLike<any>
-				? K | `${K}.${PathImpl<T[K], Exclude<keyof T[K], keyof any[]>>}`
-				: K | `${K}.${PathImpl<T[K], keyof T[K]>}`
+		? NonNullable<T[K]> extends Record<string, any>
+			? NonNullable<T[K]> extends ArrayLike<any>
+				? K | `${K}.${PathImpl<NonNullable<T[K]>, Exclude<keyof NonNullable<T[K]>, keyof any[]>>}`
+				: K | `${K}.${PathImpl<NonNullable<T[K]>, keyof NonNullable<T[K]>>}`
 			: K
 		: never
 

--- a/packages/vue/src/composables/property.ts
+++ b/packages/vue/src/composables/property.ts
@@ -8,55 +8,52 @@ export function useProperties<T extends object, Global extends GlobalHybridlyPro
 	return readonly(toReactive(computed(() => state.context.value?.view.properties as T & Global)))
 }
 
-/**
- * Accesses a property with the given type.
- * @experimental Workaround for not being able to type `useProperty`, might be removed in the future.
- */
-export function useTypedProperty<T>(path: string, fallback?: T): ComputedRef<T> {
-	return computed(() => (path as string)
-		.split('.')
-		.reduce((o: any, i: string) => o[i], state.context.value?.view.properties) as any
-		?? fallback,
-	) as any
-}
-
 /** Accesses a property with a dot notation. */
 export function useProperty<
+	F = never,
 	T = GlobalHybridlyProperties,
-	P extends Path<T> = Path<T>,
-	Fallback extends PathValue<T, P> = PathValue<T, P>
+	P extends Path<T> = Path<T>
 >(
-	path: [P] extends [never] ? string : P,
-	fallback?: Fallback,
-): ComputedRef<[PathValue<T, P>] extends [never] ? Fallback : PathValue<T, P>> {
-	return computed(() => (path as string)
-		.split('.')
-		.reduce((o: any, i: string) => o?.[i], state.context.value?.view.properties) as any
-		?? fallback,
-	)
+	path: [F] extends [never]
+		? [P] extends [never]
+			? string
+			: P
+		: string,
+): ComputedRef<[F] extends [never] ? [PathValue<T, P>] extends [never] ? never : PathValue<T, P> : F> {
+	return computed(() => {
+		return (path as string)
+			.split('.')
+			.reduce((o: any, i: string) => o?.[i], state.context.value?.view.properties) as any
+	})
 }
 
 // Credit to @diegohaz for the dot-notation access implementation
 // https://twitter.com/diegohaz/status/1309489079378219009
 
 type PathImpl<T, K extends keyof T> =
-	K extends string
-		? NonNullable<T[K]> extends Record<string, any>
-			? NonNullable<T[K]> extends ArrayLike<any>
-				? K | `${K}.${PathImpl<NonNullable<T[K]>, Exclude<keyof NonNullable<T[K]>, keyof any[]>>}`
-				: K | `${K}.${PathImpl<NonNullable<T[K]>, keyof NonNullable<T[K]>>}`
-			: K
-		: never
+		K extends string
+			? T[K] extends undefined
+				? undefined
+				: NonNullable<T[K]> extends Record<string, any>
+					? NonNullable<T[K]> extends ArrayLike<any>
+						? K | `${K}.${PathImpl<NonNullable<T[K]>, Exclude<keyof NonNullable<T[K]>, keyof any[]>>}`
+						: K | `${K}.${PathImpl<NonNullable<T[K]>, keyof NonNullable<T[K]>>}`
+					: K
+			: never
 
 type Path<T> = PathImpl<T, keyof T> | keyof T
 
 type PathValue<T, P extends Path<T>> =
-	P extends `${infer K}.${infer Rest}`
-		? K extends keyof T
-			? Rest extends Path<T[K]>
-				? PathValue<T[K], Rest>
+		P extends `${infer K}.${infer Rest}`
+			? K extends keyof T
+				? T[K] extends undefined
+					? undefined
+					: Rest extends Path<T[K]>
+						? PathValue<T[K], Rest>
+						: Rest extends Path<NonNullable<T[K]>>
+							? PathValue<NonNullable<T[K]>, Rest> | undefined
+							: never
 				: never
-			: never
-		: P extends keyof T
-			? T[P]
-			: never
+			: P extends keyof T
+				? T[P] extends undefined ? undefined : T[P]
+				: never


### PR DESCRIPTION
This PR is an attempt at fixing #57.

- [x] Fix the type of the `path` parameter of `useProperty`
- [x] Fix the return type of `useProperty`
