### PR TITLE
fix(forms): allow resetting fields after submission

### DIFF
--- a/docs/api/composables/use-form.md
+++ b/docs/api/composables/use-form.md
@@ -182,6 +182,12 @@ Returns whether the form's has recently failed. This value is reset after the [t
 
 A function that resets the given fields, or all fields if none are given. All cleared fields will also have their errors cleared.
 
+### `clear`
+
+- **Type**: `(...keys: keyof T) => void`
+
+A function that clears the given fields, or all fields if none are given. This is different than `reset`, in the sense that the fields will specifically be set to `undefined`.
+
 ### `progress`
 
 - **Type**: `{ event: AxiosProgressEvent; percentage: number }`

--- a/docs/api/composables/use-form.md
+++ b/docs/api/composables/use-form.md
@@ -55,6 +55,13 @@ Defines the shape of the form data. It is mandatory and provides typings for oth
 
 Defines whether the fields should be reset when the submission is successful.
 
+### `updateInitials`
+
+- **Type**: `boolean`
+- **Default**: `false`
+
+Defines whether the current fields should be set as the default fields after the submission is successful. If `true`, subsequent `reset` calls will reset the form to use these fields.
+
 ### `timeout`
 
 - **Type**: `number`

--- a/packages/vue/src/composables/form.ts
+++ b/packages/vue/src/composables/form.ts
@@ -93,6 +93,19 @@ export function useForm<T extends Fields = Fields>(options: FormOptions<T>) {
 	}
 
 	/**
+	 * Clear the form fields.
+	 */
+	function clear(...keys: (keyof T)[]) {
+		if (keys.length === 0) {
+			keys = Object.keys(fields)
+		}
+
+		keys.forEach((key) => {
+			delete fields[key]
+		})
+	}
+
+	/**
 	 * Submits the form.
 	 */
 	function submit(optionsOverrides?: Omit<HybridRequestOptions, 'data'>) {
@@ -222,6 +235,7 @@ export function useForm<T extends Fields = Fields>(options: FormOptions<T>) {
 
 	return reactive({
 		reset,
+		clear,
 		fields,
 		abort,
 		setErrors,

--- a/packages/vue/src/composables/form.ts
+++ b/packages/vue/src/composables/form.ts
@@ -12,8 +12,23 @@ interface FormOptions<T extends Fields> extends Omit<HybridRequestOptions, 'data
 	fields: T
 	url?: UrlResolvable | (() => UrlResolvable)
 	key?: string | false
+	/**
+	 * Defines the delay after which the `recentlySuccessful` and `recentlyFailed` variables are reset to `false`.
+	 */
 	timeout?: number
+	/**
+	 * Resets the fields of the form to their initial value after a successful submission.
+	 * @default true
+	 */
 	reset?: boolean
+	/**
+	 * Updates the initial values from the form after a successful submission.
+	 * @default false
+	 */
+	updateInitials?: boolean
+	/**
+	 * Callback executed before the form submission for transforming the fields.
+	 */
 	transform?: (fields: T) => Fields
 }
 
@@ -56,7 +71,7 @@ export function useForm<T extends Fields = Fields>(options: FormOptions<T>) {
 	const progress = ref<Progress>()
 
 	/**
-	 * Resets the form to its initial values.
+	 * Sets new initial values for the form, so subsequent resets will use thse values.
 	 */
 	function setInitial(newInitial: Partial<T>) {
 		Object.entries(newInitial).forEach(([key, value]) => {
@@ -126,7 +141,9 @@ export function useForm<T extends Fields = Fields>(options: FormOptions<T>) {
 				},
 				success: (payload, context) => {
 					clearErrors()
-					setInitial(fields)
+					if (options?.updateInitials) {
+						setInitial(fields)
+					}
 					if (options?.reset !== false) {
 						reset()
 					}


### PR DESCRIPTION
This pull request changes how `reset` behaves on a form. Currently, after a successful submission, the current fields are set as the default ones for the form, making subsequent `reset` calls ineffective to clear the fields.

This behavior is now turned off by default but may be opted-in by setting `updateInitials` to `true`.

Additionally, a new `clear` method has been added to fields can specifically be set to `undefined`, regardless of their initial value.