### PR TITLE
hotfix (laravel): dialogs & database session driver

### DIFF
--- a/packages/laravel/src/View/Factory.php
+++ b/packages/laravel/src/View/Factory.php
@@ -126,7 +126,19 @@ class Factory implements HybridResponse
         );
 
         if ($payload->dialog) {
+
+            // TODO : This is a hack to make sure the session is kept while using the database driver
+            // We should find a better way to do this in the future
+            $isUsingDatabaseSessionDriver = config('session.driver') === 'database';
+            $originalRequestSessionId = null;
+            if($isUsingDatabaseSessionDriver){
+                $originalRequestSessionId = $request->session()->getId();
+            }
+
             $payload = $this->renderDialog($request, $payload);
+
+            // Restore the original session id
+            $isUsingDatabaseSessionDriver && session()->setId($originalRequestSessionId);
         }
 
         event('hybridly.response', [


### PR DESCRIPTION
When using Laravel session driver as "database" seems like the Kernel handle function for dialog request generates a new session id, this should bring a temporary hotfix to workaround the issue.

Yet is unsure if this is the best approach.

The PR ensures we store the session ID from the original request and reset it after the request has passed into the Kernel handle method.