### PR TITLE
feat(dialogs): support closing without a server round-trip

### DIFF
--- a/docs/api/composables/use-dialog.md
+++ b/docs/api/composables/use-dialog.md
@@ -31,6 +31,12 @@ Defines whether the dialog should be shown. Generally, it is used to control the
 
 Closes the dialog, effectively assigning `false` to `show`.
 
+### `closeLocally`
+
+- **Type**: `() => void`
+
+Closes the dialog without making a server round-trip, effectively assigning `false` to `show`.
+
 ### `unmount`
 
 - **Type**: `() => void`

--- a/docs/api/router/utils.md
+++ b/docs/api/router/utils.md
@@ -76,7 +76,7 @@ This function aborts the current request. The `abort` hook will be triggered.
 
 ## `dialog.close`
 
-This function closes the current dialog. It takes the same options as the other router functions. 
+This function closes the current dialog. It takes the same options as the other router functions, as well as a `local` option that indicates whether a round-trip to the server will be made to update the base page's properties.
 
 ```ts
 router.dialog.close()

--- a/packages/core/src/dialog/index.ts
+++ b/packages/core/src/dialog/index.ts
@@ -1,8 +1,13 @@
 import { getInternalRouterContext } from '../context'
 import type { HybridRequestOptions } from '../router'
-import { performHybridNavigation } from '../router'
+import { performLocalNavigation, performHybridNavigation } from '../router'
 
 export interface CloseDialogOptions extends HybridRequestOptions {
+	/**
+	 * Close the dialog without a round-trip to the server.
+	 * @default false
+	 */
+	local?: boolean
 }
 
 /**
@@ -17,6 +22,17 @@ export async function closeDialog(options?: CloseDialogOptions) {
 	}
 
 	context.adapter.onDialogClose?.(context)
+
+	if (options?.local === true) {
+		return await performLocalNavigation(url, {
+			preserveScroll: true,
+			preserveState: true,
+			dialog: false,
+			component: context.view.component,
+			properties: context.view.properties,
+			...options,
+		})
+	}
 
 	return await performHybridNavigation({
 		url,

--- a/packages/core/src/router/router.ts
+++ b/packages/core/src/router/router.ts
@@ -33,7 +33,7 @@ export const router: Router = {
 	put: async(url, options = {}) => await performHybridNavigation({ preserveState: true, ...options, url, method: 'PUT' }),
 	patch: async(url, options = {}) => await performHybridNavigation({ preserveState: true, ...options, url, method: 'PATCH' }),
 	delete: async(url, options = {}) => await performHybridNavigation({ preserveState: true, ...options, url, method: 'DELETE' }),
-	local: async(url, options) => await performLocalNavigation(url, options),
+	local: async(url, options = {}) => await performLocalNavigation(url, options),
 	external: (url, data = {}) => navigateToExternalUrl(url, data),
 	to: async(name, parameters, options) => {
 		const url = generateRouteFromName(name, parameters)
@@ -410,7 +410,7 @@ async function initializeRouter(): Promise<InternalRouterContext> {
 }
 
 /** Performs a local navigation to the given component without a round-trip. */
-async function performLocalNavigation(targetUrl: UrlResolvable, options: ComponentNavigationOptions) {
+export async function performLocalNavigation(targetUrl: UrlResolvable, options?: ComponentNavigationOptions) {
 	const context = getRouterContext()
 	const url = normalizeUrl(targetUrl)
 
@@ -418,11 +418,11 @@ async function performLocalNavigation(targetUrl: UrlResolvable, options: Compone
 		...options,
 		payload: {
 			version: context.version,
-			dialog: context.dialog,
+			dialog: options?.dialog === false ? undefined : (options?.dialog ?? context.dialog),
 			url,
 			view: {
-				component: options.component ?? context.view.component,
-				properties: options.properties ?? {},
+				component: options?.component ?? context.view.component,
+				properties: options?.properties ?? {},
 			},
 		},
 	})

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -10,6 +10,8 @@ export type ConditionalNavigationOption<T extends boolean | string> =
 	| ((payload: NavigationOptions) => T)
 
 export interface ComponentNavigationOptions {
+	/** Dialog data. */
+	dialog?: Dialog | false
 	/** Name of the component to use. */
 	component?: string
 	/** Properties to apply to the component. */

--- a/packages/vue/src/composables/dialog.ts
+++ b/packages/vue/src/composables/dialog.ts
@@ -10,6 +10,8 @@ export function useDialog() {
 	return {
 		/** Closes the dialog. */
 		close: () => router.dialog.close(),
+		/** Closes the dialog without a server round-trip. */
+		closeLocally: () => router.dialog.close({ local: true }),
 		/** Unmounts the dialog. Should be called after its closing animations. */
 		unmount: () => dialogStore.removeComponent(),
 		/** Whether the dialog is shown. */


### PR DESCRIPTION
With this PR, you may use `router.dialog.close({ local: true })` or `const { closeLocally } = useDialog()` to close the current dialog without making an actual request to the base page.