### PR TITLE
fix(useProperty): support `any`, arrays, `Readonly`, and Cyclic Types

### DIFF
--- a/packages/vue/build.config.ts
+++ b/packages/vue/build.config.ts
@@ -17,6 +17,7 @@ export default defineBuildConfig({
 		'hybridly',
 		'@vue/shared',
 		'axios',
+		'@clickbar/dot-diver',
 	],
 	rollup: {
 		emitCJS: true,

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -53,6 +53,7 @@
     "qs": "^6.11.1"
   },
   "devDependencies": {
+    "@clickbar/dot-diver": "^1.0.1",
     "@types/lodash": "^4.14.191",
     "@types/lodash.clonedeep": "^4.5.7",
     "@types/lodash.isequal": "^4.5.6",

--- a/packages/vue/src/composables/property.ts
+++ b/packages/vue/src/composables/property.ts
@@ -1,5 +1,7 @@
 import type { ComputedRef } from 'vue'
 import { computed, readonly } from 'vue'
+import { getByPath } from '@clickbar/dot-diver'
+import type { Path, PathValue, SearchableObject } from '@clickbar/dot-diver'
 import { state } from '../stores/state'
 import { toReactive } from '../utils'
 
@@ -10,48 +12,10 @@ export function useProperties<T extends object, Global extends GlobalHybridlyPro
 
 /** Accesses a property with a dot notation. */
 export function useProperty<
-	F = never,
-	T = GlobalHybridlyProperties,
-	P extends Path<T> = Path<T>
+	T extends SearchableObject = GlobalHybridlyProperties,
+	P extends Path<T> & string = Path<T> & string
 >(
-	path: [F] extends [never]
-		? ([P] extends [never] ? string : P)
-		: string,
-): ComputedRef<[F] extends [never] ? ([PathValue<T, P>] extends [never] ? never : PathValue<T, P>) : F> {
-	return computed(() => {
-		return (path as string)
-			.split('.')
-			.reduce((o: any, i: string) => o?.[i], state.context.value?.view.properties) as any
-	})
+	path: P,
+): ComputedRef<PathValue<T, P>> {
+	return computed(() => getByPath(state.context.value?.view.properties as GlobalHybridlyProperties, path) as PathValue<T, P>)
 }
-
-// Credit to @diegohaz for the dot-notation access implementation
-// https://twitter.com/diegohaz/status/1309489079378219009
-
-type PathImpl<T, K extends keyof T> =
-		K extends string
-			? T[K] extends undefined
-				? undefined
-				: NonNullable<T[K]> extends Record<string, any>
-					? NonNullable<T[K]> extends ArrayLike<any>
-						? K | `${K}.${PathImpl<NonNullable<T[K]>, Exclude<keyof NonNullable<T[K]>, keyof any[]>>}`
-						: K | `${K}.${PathImpl<NonNullable<T[K]>, keyof NonNullable<T[K]>>}`
-					: K
-			: never
-
-type Path<T> = PathImpl<T, keyof T> | keyof T
-
-type PathValue<T, P extends Path<T>> =
-		P extends `${infer K}.${infer Rest}`
-			? K extends keyof T
-				? T[K] extends undefined
-					? undefined
-					: Rest extends Path<T[K]>
-						? PathValue<T[K], Rest>
-						: Rest extends Path<NonNullable<T[K]>>
-							? PathValue<NonNullable<T[K]>, Rest> | undefined
-							: never
-				: never
-			: P extends keyof T
-				? T[P] extends undefined ? undefined : T[P]
-				: never

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,7 @@ importers:
 
   packages/vue:
     specifiers:
+      '@clickbar/dot-diver': ^1.0.1
       '@hybridly/config': workspace:*
       '@hybridly/core': workspace:*
       '@hybridly/progress-plugin': workspace:*
@@ -187,6 +188,7 @@ importers:
       nprogress: 0.2.0
       qs: 6.11.1
     devDependencies:
+      '@clickbar/dot-diver': 1.0.1
       '@types/lodash': 4.14.191
       '@types/lodash.clonedeep': 4.5.7
       '@types/lodash.isequal': 4.5.6
@@ -522,6 +524,10 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
+
+  /@clickbar/dot-diver/1.0.1:
+    resolution: {integrity: sha512-Jepnq6e/2DApECLgXzflMyo069oW3j36wdceCCydcsxWl+0nHcBgZ47lucb8JG3L2QJwa1EXj4kOer+ScXKtUg==}
+    dev: true
 
   /@docsearch/css/3.3.3:
     resolution: {integrity: sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg==}


### PR DESCRIPTION
The journey began when we encountered a "Type instantiation is excessively deep and possibly infinite.ts(2589)" bug while using `useProperty()`. Upon further investigation by @saibotk, the `any` type was identified as the root cause. We addressed the typing issue, but additional bugs emerged in the process.

To handle the growing complexity of the resulting type, we decided to extract `Path` and `PathValue` into their own dedicated package called [dot-diver 🤿](https://github.com/clickbar/dot-diver).

- [x] Resolved issues with `any` usage
- [x] Added support for arrays (e.g. `'environment.users.0.name'`)
- [x] Improved handling of cyclic dependencies between types by introducing a `depth` parameter
- [x] Tested typing and functions

The cyclic dependency aspect is rather big. In Laravel, relationships between models often introduce cyclic dependencies between the types of these models.
For example:

```typescript
type User = {
  cars: Car[]
}

type Car = {
  user: User
}
```

TypeScript will attempt to traverse these models as far as it can (currently, the default is 50 steps, i think) before throwing the same error as encountered with `any`. Our package includes a default depth parameter which sets a limit on how far TypeScript can traverse this chain. At the moment, the default value for this limit is 10, which is relatively low to protect against types becoming too large if they have numerous properties, including other objects and cyclic dependencies.

Users can still provide a longer path, but they will not receive any validation for it, and the returned value will be of an unknown type.

Additionally, we removed the generic parameter `F`. It appears that the intention was to provide the possibility to override return and parameter types. Is this functionality still needed?