### PR TITLE
docs(installation): improve preset usage documentation

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -6,9 +6,7 @@ You may install Hybridly in a fresh Laravel project using the preset. If you pre
 
 ## Preset
 
-The easiest way to get started with Hybridly in a [**fresh Laravel project**](https://laravel.com/docs/installation) is to use the preset.
-
-Run the following command in the root of your project.
+The recommended way of installing Hybridly is to use the preset in a [**fresh Laravel project**](https://laravel.com/docs/installation). Run the following command in the root of your project:
 
 :::code-group
 ```bash [npm]
@@ -22,20 +20,16 @@ yarn dlx @preset/cli apply hybridly/preset
 ```
 :::
 
-The presets automatically sets up [**Tailwind CSS**](https://tailwindcss.com), and [**Pest**](https://pestphp.com).
+The preset automatically sets up [**Tailwind CSS**](https://tailwindcss.com) and [**Pest**](https://pestphp.com). You may add any of the following flags to the previous command to customize the preset:
 
-You may add any of the following flags to the previous command to customize the preset.
+| Flag          | Description                                                                           |
+| ------------- | ------------------------------------------------------------------------------------- |
+| `--i18n`      | Install and setup [**vue-i18n**](https://vue-i18n.intlify.dev/)                       |
+| `--no-pest`   | Do not setup [**Pest**](https://pestphp.com/)                                         |
+| `--no-strict` | Do not setup Laravel strict mode                                                      |
+| `--no-ide`    | Do not setup [**laravel-ide-helper**](https://github.com/barryvdh/laravel-ide-helper) |
 
-|Flag|Description|
-|---|---|
-|`--i18n`|Install and setup [**vue-i18n**](https://vue-i18n.intlify.dev/)|
-|`--no-auto-imports`|Do not setup [**unplugin-auto-import**](https://github.com/antfu/unplugin-auto-import) and [**unplugin-vue-components**](https://github.com/antfu/unplugin-vue-components).|
-|`--no-icons`|Do not setup [**unplugin-icons**](https://github.com/antfu/unplugin-icons).|
-|`--no-ide`|Do not setup [**laravel-ide-helper**](https://github.com/barryvdh/laravel-ide-helper).|
-|`--no-pest`|Do not setup [**Pest**](https://pestphp.com/).|
-|`--no-strict`|Do not setup Laravel strict mode.|
-
-More information about the preset can be found on the [**repository**](https://github.com/hybridly/preset).
+More information about the preset can be found on its [**repository**](https://github.com/hybridly/preset).
 
 
 ## Server-side setup

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -22,6 +22,8 @@ yarn dlx @preset/cli apply hybridly/preset
 ```
 :::
 
+The presets automatically sets up [**Tailwind CSS**](https://tailwindcss.com), and [**Pest**](https://pestphp.com).
+
 You may add any of the following flags to the previous command to customize the preset.
 
 |Flag|Description|

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -6,15 +6,35 @@ You may install Hybridly in a fresh Laravel project using the preset. If you pre
 
 ## Preset
 
-The recommended way of installing Hybridly is to create a fresh Laravel project and use the preset.
+The easiest way to get started with Hybridly in a **fresh Laravel project** is to use the preset.
 
-```bash
-composer create-project laravel/laravel my-project
-cd my-project
-npx @preset/cli apply hybridly/preset // [!code focus]
+Run the following command in the root of your project.
+
+:::code-group
+```bash [npm]
+npx @preset/cli apply hybridly/preset
 ```
+```bash [pnpm]
+pnpm dlx @preset/cli apply hybridly/preset
+```
+```bash [yarn]
+yarn dlx @preset/cli apply hybridly/preset
+```
+:::
 
-This will configure Tailwind CSS, [Pest](https://pestphp.com), and optionally internationalization through [`vue-i18n`](https://github.com/intlify/vue-i18n-next). More information about the options on the [repository](https://github.com/hybridly/preset).
+You may add any of the following flags to the previous command to customize the preset.
+
+|Flag|Description|
+|---|---|
+|`--i18n`|Install and setup [**vue-i18n**](https://vue-i18n.intlify.dev/)|
+|`--no-auto-imports`|Do not setup [**unplugin-auto-import**](https://github.com/antfu/unplugin-auto-import) and [**unplugin-vue-components**](https://github.com/antfu/unplugin-vue-components).|
+|`--no-icons`|Do not setup [**unplugin-icons**](https://github.com/antfu/unplugin-icons).|
+|`--no-ide`|Do not setup [**laravel-ide-helper**](https://github.com/barryvdh/laravel-ide-helper).|
+|`--no-pest`|Do not setup [**Pest**](https://pestphp.com/).|
+|`--no-strict`|Do not setup Laravel strict mode.|
+
+More information about the preset can be found on the [**repository**](https://github.com/hybridly/preset).
+
 
 ## Server-side setup
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -6,7 +6,7 @@ You may install Hybridly in a fresh Laravel project using the preset. If you pre
 
 ## Preset
 
-The easiest way to get started with Hybridly in a **fresh Laravel project** is to use the preset.
+The easiest way to get started with Hybridly in a [**fresh Laravel project**](https://laravel.com/docs/installation) is to use the preset.
 
 Run the following command in the root of your project.
 
@@ -148,7 +148,7 @@ composer require hybridly/laravel
 php artisan hybridly:install
 ```
 
-The last command extracted the middleware that is required to intercept responses and convert them to the Hybridly protocol. 
+The last command extracted the middleware that is required to intercept responses and convert them to the Hybridly protocol.
 
 That middleware is, by default, located in `app/Http/Middleware/HandleHybridRequests.php`. It has automatically been registered into the `web` middleware group in `app/Http/Kernel.php`.
 


### PR DESCRIPTION
This PR is an attempt at improving the documentation for using the preset.

Here's a summary of the changes:

- [x] Simplify the code snippet to only include the command for running the preset.
- [x] Add commands for `pnpm` and `yarn`
- [x] Add documentation of the flags that can be used with the preset, with links to the relevant projects.

### Simplifying the code snippet

I believe it is safe to assume that users that will run the preset to install Hybridly already know how to install Laravel, so I suggest removing the extra line that shows how to install Laravel and instead adding a link to Laravel's installation instructions.

### Add commands for `pnpm` and `yarn`

The current code snippet is updated to a code group to show the commands for the three major package managers. While the preset does not yet detect which package manager initiated the installation, I believe this is a step in the right direction.

### Add documentation of available flags

This adds a list of flags and their effect to the documentation. Users no longer have to switch to GitHub to find the information. I believe the list of flags is sufficiently small that it won't create a maintenance issue. The link to the repository is kept too.

As a bonus, I've added the missing documentation for the following flags: `--no-ide`, `--no-strict`