### PR TITLE
feat(laravel): support lazy and partial properties in data objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan-deprecation-rules": "^1.1.3",
         "phpstan/phpstan-phpunit": "^1.3.10",
-        "spatie/laravel-data": "^3.2.0",
+        "spatie/laravel-data": "^3.4.4",
         "spatie/laravel-ray": "^1.32.3",
         "spatie/laravel-typescript-transformer": "^2.1.7",
         "spatie/x-ray": "^1.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c499a932d3060c62ea21e3767c3442a",
+    "content-hash": "50ca64bbb7e3ca279f908b412cd81888",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1203,16 +1203,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v10.6.2",
+            "version": "v10.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "13dc93889617427352f72b6aa8b195b252af1197"
+                "reference": "ddbbb2b50388721fe63312bb4469cae13163fd36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/13dc93889617427352f72b6aa8b195b252af1197",
-                "reference": "13dc93889617427352f72b6aa8b195b252af1197",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/ddbbb2b50388721fe63312bb4469cae13163fd36",
+                "reference": "ddbbb2b50388721fe63312bb4469cae13163fd36",
                 "shasum": ""
             },
             "require": {
@@ -1399,7 +1399,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-04-05T15:28:17+00:00"
+            "time": "2023-04-11T14:11:49+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -1651,16 +1651,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.12.3",
+            "version": "3.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "81e87e74dd5213795c7846d65089712d2dda90ce"
+                "reference": "e2a279d7f47d9098e479e8b21f7fb8b8de230158"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/81e87e74dd5213795c7846d65089712d2dda90ce",
-                "reference": "81e87e74dd5213795c7846d65089712d2dda90ce",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/e2a279d7f47d9098e479e8b21f7fb8b8de230158",
+                "reference": "e2a279d7f47d9098e479e8b21f7fb8b8de230158",
                 "shasum": ""
             },
             "require": {
@@ -1722,7 +1722,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.12.3"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.14.0"
             },
             "funding": [
                 {
@@ -1732,13 +1732,9 @@
                 {
                     "url": "https://github.com/frankdejonge",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-18T15:32:41+00:00"
+            "time": "2023-04-11T18:11:47+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -3065,16 +3061,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v6.2.7",
+            "version": "v6.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "61e90f94eb014054000bc902257d2763fac09166"
+                "reference": "e95f1273b3953c3b5e5341172dae838bacee11ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/61e90f94eb014054000bc902257d2763fac09166",
-                "reference": "61e90f94eb014054000bc902257d2763fac09166",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/e95f1273b3953c3b5e5341172dae838bacee11ee",
+                "reference": "e95f1273b3953c3b5e5341172dae838bacee11ee",
                 "shasum": ""
             },
             "require": {
@@ -3116,7 +3112,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v6.2.7"
+                "source": "https://github.com/symfony/error-handler/tree/v6.2.9"
             },
             "funding": [
                 {
@@ -3132,7 +3128,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T08:44:56+00:00"
+            "time": "2023-04-11T16:03:19+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -3440,16 +3436,16 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.2.8",
+            "version": "v6.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "9563229e56076070d92ca30c089e801e8a4629a3"
+                "reference": "02246510cf7031726f7237138d61b796b95799b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9563229e56076070d92ca30c089e801e8a4629a3",
-                "reference": "9563229e56076070d92ca30c089e801e8a4629a3",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/02246510cf7031726f7237138d61b796b95799b3",
+                "reference": "02246510cf7031726f7237138d61b796b95799b3",
                 "shasum": ""
             },
             "require": {
@@ -3531,7 +3527,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.2.8"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.2.9"
             },
             "funding": [
                 {
@@ -3547,7 +3543,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-31T12:00:10+00:00"
+            "time": "2023-04-13T16:41:43+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -5303,16 +5299,16 @@
     "packages-dev": [
         {
             "name": "brianium/paratest",
-            "version": "v7.1.2",
+            "version": "v7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paratestphp/paratest.git",
-                "reference": "10e66ccdad397200f8129a034f0d3bf8cbe4c524"
+                "reference": "f394bb33b2bb7a4120b531e8991409b7aa62fc43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/10e66ccdad397200f8129a034f0d3bf8cbe4c524",
-                "reference": "10e66ccdad397200f8129a034f0d3bf8cbe4c524",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/f394bb33b2bb7a4120b531e8991409b7aa62fc43",
+                "reference": "f394bb33b2bb7a4120b531e8991409b7aa62fc43",
                 "shasum": ""
             },
             "require": {
@@ -5323,23 +5319,23 @@
                 "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "jean85/pretty-package-versions": "^2.0.5",
                 "php": "~8.1.0 || ~8.2.0",
-                "phpunit/php-code-coverage": "^10.0.2",
+                "phpunit/php-code-coverage": "^10.1.0",
                 "phpunit/php-file-iterator": "^4.0.1",
                 "phpunit/php-timer": "^6.0",
-                "phpunit/phpunit": "^10.0.17",
-                "sebastian/environment": "^6.0",
-                "symfony/console": "^6.2.7",
-                "symfony/process": "^6.2.7"
+                "phpunit/phpunit": "^10.1.0",
+                "sebastian/environment": "^6.0.1",
+                "symfony/console": "^6.2.8",
+                "symfony/process": "^6.2.8"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^11.1.0",
                 "ext-pcov": "*",
                 "ext-posix": "*",
                 "infection/infection": "^0.26.19",
-                "phpstan/phpstan": "^1.10.7",
+                "phpstan/phpstan": "^1.10.13",
                 "phpstan/phpstan-deprecation-rules": "^1.1.3",
-                "phpstan/phpstan-phpunit": "^1.3.10",
-                "phpstan/phpstan-strict-rules": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.3.11",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
                 "squizlabs/php_codesniffer": "^3.7.2",
                 "symfony/filesystem": "^6.2.7"
             },
@@ -5382,7 +5378,7 @@
             ],
             "support": {
                 "issues": "https://github.com/paratestphp/paratest/issues",
-                "source": "https://github.com/paratestphp/paratest/tree/v7.1.2"
+                "source": "https://github.com/paratestphp/paratest/tree/v7.1.3"
             },
             "funding": [
                 {
@@ -5394,7 +5390,7 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2023-03-20T15:15:41+00:00"
+            "time": "2023-04-14T06:17:37+00:00"
         },
         {
             "name": "composer/pcre",
@@ -5864,16 +5860,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.15.1",
+            "version": "2.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "e864ac957acd66e1565f25efda61e37791a5db0b"
+                "reference": "aac9304c5ed61bf7b1b7a6064bf9806ab842ce73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/e864ac957acd66e1565f25efda61e37791a5db0b",
-                "reference": "e864ac957acd66e1565f25efda61e37791a5db0b",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/aac9304c5ed61bf7b1b7a6064bf9806ab842ce73",
+                "reference": "aac9304c5ed61bf7b1b7a6064bf9806ab842ce73",
                 "shasum": ""
             },
             "require": {
@@ -5923,7 +5919,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.15.1"
+                "source": "https://github.com/filp/whoops/tree/2.15.2"
             },
             "funding": [
                 {
@@ -5931,7 +5927,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T18:09:13+00:00"
+            "time": "2023-04-12T12:00:00+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -6594,40 +6590,40 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v7.4.0",
+            "version": "v7.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "42bab217d4913d6610f341d0468cec860aae165e"
+                "reference": "bbbc6fb9c1ee88f8aa38e47abd15c465f946f85e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/42bab217d4913d6610f341d0468cec860aae165e",
-                "reference": "42bab217d4913d6610f341d0468cec860aae165e",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/bbbc6fb9c1ee88f8aa38e47abd15c465f946f85e",
+                "reference": "bbbc6fb9c1ee88f8aa38e47abd15c465f946f85e",
                 "shasum": ""
             },
             "require": {
-                "filp/whoops": "^2.15.1",
+                "filp/whoops": "^2.15.2",
                 "nunomaduro/termwind": "^1.15.1",
                 "php": "^8.1.0",
-                "symfony/console": "^6.2.7"
+                "symfony/console": "^6.2.8"
             },
             "conflict": {
-                "phpunit/phpunit": "<10.0.17"
+                "phpunit/phpunit": "<10.1.0"
             },
             "require-dev": {
-                "brianium/paratest": "^7.1.2",
-                "laravel/framework": "^10.5.1",
-                "laravel/pint": "^1.7.0",
-                "laravel/sail": "^1.21.3",
+                "brianium/paratest": "^7.1.3",
+                "laravel/framework": "^10.7.1",
+                "laravel/pint": "^1.8.0",
+                "laravel/sail": "^1.21.4",
                 "laravel/sanctum": "^3.2.1",
                 "laravel/tinker": "^2.8.1",
                 "nunomaduro/larastan": "^2.5.1",
-                "orchestra/testbench-core": "^8.2.0",
-                "pestphp/pest": "^2.3.0",
-                "phpunit/phpunit": "^10.0.19",
-                "sebastian/environment": "^6.0.0",
-                "spatie/laravel-ignition": "^2.0.0"
+                "orchestra/testbench-core": "^8.4.2",
+                "pestphp/pest": "^2.5.0",
+                "phpunit/phpunit": "^10.1.0",
+                "sebastian/environment": "^6.0.1",
+                "spatie/laravel-ignition": "^2.1.0"
             },
             "type": "library",
             "extra": {
@@ -6686,7 +6682,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-03-31T08:17:12+00:00"
+            "time": "2023-04-14T10:39:16+00:00"
         },
         {
             "name": "nunomaduro/larastan",
@@ -6786,26 +6782,26 @@
         },
         {
             "name": "orchestra/testbench",
-            "version": "v8.3.0",
+            "version": "v8.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "8caa43318a0a4a0f525eb3edec08627565a3410c"
+                "reference": "b432b7c2f33c48dca28a875c82d7f0ca0883fb78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/8caa43318a0a4a0f525eb3edec08627565a3410c",
-                "reference": "8caa43318a0a4a0f525eb3edec08627565a3410c",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/b432b7c2f33c48dca28a875c82d7f0ca0883fb78",
+                "reference": "b432b7c2f33c48dca28a875c82d7f0ca0883fb78",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "fakerphp/faker": "^1.21",
-                "laravel/framework": ">=10.6.1 <10.7.0",
+                "laravel/framework": ">=10.6.1 <10.8.0",
                 "mockery/mockery": "^1.5.1",
-                "orchestra/testbench-core": ">=8.4.0 <8.5.0",
+                "orchestra/testbench-core": ">=8.4.2 <8.5.0",
                 "php": "^8.1",
-                "phpunit/phpunit": "^9.6 || ^10.0.7",
+                "phpunit/phpunit": "^9.6 || ^10.1",
                 "spatie/laravel-ray": "^1.32.4",
                 "symfony/process": "^6.2",
                 "symfony/yaml": "^6.2",
@@ -6835,22 +6831,22 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/testbench/issues",
-                "source": "https://github.com/orchestral/testbench/tree/v8.3.0"
+                "source": "https://github.com/orchestral/testbench/tree/v8.4.0"
             },
-            "time": "2023-04-05T00:11:08+00:00"
+            "time": "2023-04-14T09:57:38+00:00"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "v8.4.0",
+            "version": "v8.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "545d10a6d5e59c4831ff7301c470dc12f58723aa"
+                "reference": "a244ae2cd9067e280581ae98f010954be73a3b1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/545d10a6d5e59c4831ff7301c470dc12f58723aa",
-                "reference": "545d10a6d5e59c4831ff7301c470dc12f58723aa",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/a244ae2cd9067e280581ae98f010954be73a3b1f",
+                "reference": "a244ae2cd9067e280581ae98f010954be73a3b1f",
                 "shasum": ""
             },
             "require": {
@@ -6864,18 +6860,18 @@
                 "mockery/mockery": "^1.5.1",
                 "orchestra/canvas": "^8.1",
                 "phpstan/phpstan": "^1.10.7",
-                "phpunit/phpunit": "~10.0.7",
+                "phpunit/phpunit": "^10.1",
                 "spatie/laravel-ray": "^1.32.4",
                 "symfony/process": "^6.2",
                 "symfony/yaml": "^6.2",
                 "vlucas/phpdotenv": "^5.4.1"
             },
             "suggest": {
-                "brianium/paratest": "Allow using parallel tresting (^6.4 || ^7.0).",
+                "brianium/paratest": "Allow using parallel tresting (^6.4 || ^7.1.4).",
                 "fakerphp/faker": "Allow using Faker for testing (^1.21).",
                 "laravel/framework": "Required for testing (^10.6.1).",
                 "mockery/mockery": "Allow using Mockery for testing (^1.5.1).",
-                "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^6.4 || ^7.0).",
+                "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^6.4 || ^7.4).",
                 "orchestra/testbench-browser-kit": "Allow using legacy Laravel BrowserKit for testing (^8.0).",
                 "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^8.0).",
                 "phpunit/phpunit": "Allow using PHPUnit for testing (^9.6 || ^10.0.7).",
@@ -6924,7 +6920,7 @@
                 "issues": "https://github.com/orchestral/testbench/issues",
                 "source": "https://github.com/orchestral/testbench-core"
             },
-            "time": "2023-04-04T23:51:20+00:00"
+            "time": "2023-04-14T09:30:29+00:00"
         },
         {
             "name": "permafrost-dev/code-snippets",
@@ -7055,29 +7051,29 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v2.4.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "12c75524a2548e787ade52023d6e2d5725dba9bb"
+                "reference": "9070b1237775856d052b6ab5aadf0904dd3d4b06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/12c75524a2548e787ade52023d6e2d5725dba9bb",
-                "reference": "12c75524a2548e787ade52023d6e2d5725dba9bb",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/9070b1237775856d052b6ab5aadf0904dd3d4b06",
+                "reference": "9070b1237775856d052b6ab5aadf0904dd3d4b06",
                 "shasum": ""
             },
             "require": {
-                "brianium/paratest": "^7.1.2",
+                "brianium/paratest": "^7.1.3",
                 "nunomaduro/collision": "^7.4.0",
                 "nunomaduro/termwind": "^1.15.1",
                 "pestphp/pest-plugin": "^2.0.1",
                 "pestphp/pest-plugin-arch": "^2.1.1",
                 "php": "^8.1.0",
-                "phpunit/phpunit": "^10.0.19"
+                "phpunit/phpunit": "^10.1.0"
             },
             "conflict": {
-                "phpunit/phpunit": ">10.0.19",
+                "phpunit/phpunit": ">10.1.0",
                 "webmozart/assert": "<1.11.0"
             },
             "require-dev": {
@@ -7138,7 +7134,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v2.4.0"
+                "source": "https://github.com/pestphp/pest/tree/v2.5.0"
             },
             "funding": [
                 {
@@ -7150,7 +7146,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-02T20:12:31+00:00"
+            "time": "2023-04-14T10:13:56+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -7811,16 +7807,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.11",
+            "version": "1.10.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "8aa62e6ea8b58ffb650e02940e55a788cbc3fe21"
+                "reference": "f07bf8c6980b81bf9e49d44bd0caf2e737614a70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8aa62e6ea8b58ffb650e02940e55a788cbc3fe21",
-                "reference": "8aa62e6ea8b58ffb650e02940e55a788cbc3fe21",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f07bf8c6980b81bf9e49d44bd0caf2e737614a70",
+                "reference": "f07bf8c6980b81bf9e49d44bd0caf2e737614a70",
                 "shasum": ""
             },
             "require": {
@@ -7869,7 +7865,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-04T19:17:42+00:00"
+            "time": "2023-04-12T19:29:52+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -7973,16 +7969,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.0.2",
+            "version": "10.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "20800e84296ea4732f9a125e08ce86b4004ae3e4"
+                "reference": "fc4f5ee614fa82d50ecf9014b51af0a9561f3df8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/20800e84296ea4732f9a125e08ce86b4004ae3e4",
-                "reference": "20800e84296ea4732f9a125e08ce86b4004ae3e4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/fc4f5ee614fa82d50ecf9014b51af0a9561f3df8",
+                "reference": "fc4f5ee614fa82d50ecf9014b51af0a9561f3df8",
                 "shasum": ""
             },
             "require": {
@@ -8010,7 +8006,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.0-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -8038,7 +8034,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.0.2"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.0"
             },
             "funding": [
                 {
@@ -8046,7 +8043,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T13:00:19+00:00"
+            "time": "2023-04-13T07:08:27+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -8291,16 +8288,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.0.19",
+            "version": "10.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "20c23e85c86e5c06d63538ba464e8054f4744e62"
+                "reference": "5a477aea03e61329132935689ae2d73f418f5e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/20c23e85c86e5c06d63538ba464e8054f4744e62",
-                "reference": "20c23e85c86e5c06d63538ba464e8054f4744e62",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5a477aea03e61329132935689ae2d73f418f5e25",
+                "reference": "5a477aea03e61329132935689ae2d73f418f5e25",
                 "shasum": ""
             },
             "require": {
@@ -8314,7 +8311,7 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.0",
+                "phpunit/php-code-coverage": "^10.1",
                 "phpunit/php-file-iterator": "^4.0",
                 "phpunit/php-invoker": "^4.0",
                 "phpunit/php-text-template": "^3.0",
@@ -8340,7 +8337,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.0-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -8372,7 +8369,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.1.0"
             },
             "funding": [
                 {
@@ -8388,7 +8385,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-27T11:46:33+00:00"
+            "time": "2023-04-14T05:15:09+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -8494,21 +8491,21 @@
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.0.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -8528,7 +8525,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for PSR-7 HTTP message factories",
@@ -8543,9 +8540,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/master"
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
             },
-            "time": "2019-04-30T12:38:16+00:00"
+            "time": "2023-04-10T20:10:41+00:00"
         },
         {
             "name": "psr/http-message",
@@ -9013,16 +9010,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc"
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b6f3694c6386c7959915a0037652e0c40f6f69cc",
-                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/43c751b41d74f96cbbd4e07b7aec9675651e2951",
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951",
                 "shasum": ""
             },
             "require": {
@@ -9064,7 +9061,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.1"
             },
             "funding": [
                 {
@@ -9072,7 +9070,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:03:04+00:00"
+            "time": "2023-04-11T05:39:26+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -9617,16 +9615,16 @@
         },
         {
             "name": "spatie/laravel-data",
-            "version": "3.4.1",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-data.git",
-                "reference": "d0e9e172bfa5baebffe7702865bd38150a6321f7"
+                "reference": "d0208dbc6d49ca44ef3ba0dd542cd83ba15bcbc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-data/zipball/d0e9e172bfa5baebffe7702865bd38150a6321f7",
-                "reference": "d0e9e172bfa5baebffe7702865bd38150a6321f7",
+                "url": "https://api.github.com/repos/spatie/laravel-data/zipball/d0208dbc6d49ca44ef3ba0dd542cd83ba15bcbc4",
+                "reference": "d0208dbc6d49ca44ef3ba0dd542cd83ba15bcbc4",
                 "shasum": ""
             },
             "require": {
@@ -9688,7 +9686,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-data/issues",
-                "source": "https://github.com/spatie/laravel-data/tree/3.4.1"
+                "source": "https://github.com/spatie/laravel-data/tree/3.4.4"
             },
             "funding": [
                 {
@@ -9696,7 +9694,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-07T13:28:19+00:00"
+            "time": "2023-04-14T08:24:46+00:00"
         },
         {
             "name": "spatie/laravel-ray",
@@ -9785,21 +9783,21 @@
         },
         {
             "name": "spatie/laravel-typescript-transformer",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-typescript-transformer.git",
-                "reference": "70e49fd46a87a8a6e540547031c31effcfc0c176"
+                "reference": "66e699150679a151877d8070b8d2c9b27a7ef82f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-typescript-transformer/zipball/70e49fd46a87a8a6e540547031c31effcfc0c176",
-                "reference": "70e49fd46a87a8a6e540547031c31effcfc0c176",
+                "url": "https://api.github.com/repos/spatie/laravel-typescript-transformer/zipball/66e699150679a151877d8070b8d2c9b27a7ef82f",
+                "reference": "66e699150679a151877d8070b8d2c9b27a7ef82f",
                 "shasum": ""
             },
             "require": {
                 "illuminate/console": "^8.83|^9.30|^10.0",
-                "php": "^8.0",
+                "php": "^8.1",
                 "spatie/laravel-package-tools": "^1.12",
                 "spatie/typescript-transformer": "^2.1.13"
             },
@@ -9851,7 +9849,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-typescript-transformer/issues",
-                "source": "https://github.com/spatie/laravel-typescript-transformer/tree/2.2.0"
+                "source": "https://github.com/spatie/laravel-typescript-transformer/tree/2.3.0"
             },
             "funding": [
                 {
@@ -9863,7 +9861,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-24T09:57:55+00:00"
+            "time": "2023-04-14T08:14:48+00:00"
         },
         {
             "name": "spatie/macroable",

--- a/packages/laravel/src/HybridlyServiceProvider.php
+++ b/packages/laravel/src/HybridlyServiceProvider.php
@@ -9,6 +9,7 @@ use Hybridly\Commands\RoutesCommand;
 use Hybridly\Http\Controller;
 use Hybridly\PropertiesResolver\PropertiesResolver;
 use Hybridly\PropertiesResolver\RequestPropertiesResolver;
+use Hybridly\Support\Data\PartialLazy;
 use Hybridly\Testing\TestFileViewFinder;
 use Hybridly\Testing\TestResponseMacros;
 use Illuminate\Http\Request;
@@ -16,6 +17,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Testing\TestResponse;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Factory;
+use Spatie\LaravelData\Lazy;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -90,6 +92,9 @@ class HybridlyServiceProvider extends PackageServiceProvider
             return $this->match(['GET', 'HEAD'], $uri, Controller::class)
                 ->defaults('component', $component)
                 ->defaults('properties', $properties);
+        });
+        Lazy::macro('partial', function (\Closure $value): PartialLazy {
+            return new PartialLazy($value);
         });
     }
 

--- a/packages/laravel/src/Support/Data/PartialLazy.php
+++ b/packages/laravel/src/Support/Data/PartialLazy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Hybridly\Support\Data;
+
+use Hybridly\Support\Partial;
+use Spatie\LaravelData\Support\Lazy\ConditionalLazy;
+
+class PartialLazy extends ConditionalLazy
+{
+    public function __construct(
+        \Closure $closure,
+    ) {
+        parent::__construct(fn () => true, $closure);
+    }
+
+    public function resolve(): Partial
+    {
+        return hybridly()->partial($this->value);
+    }
+}

--- a/tests/src/Fixtures/Data/DataObjectWithLazyProperty.php
+++ b/tests/src/Fixtures/Data/DataObjectWithLazyProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Hybridly\Tests\Fixtures\Data;
+
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Lazy;
+
+class DataObjectWithLazyProperty extends Data
+{
+    public function __construct(
+        public readonly bool $foo,
+        public readonly Lazy|string $bar,
+    ) {
+    }
+}

--- a/tests/src/Laravel/Support/DataTest.php
+++ b/tests/src/Laravel/Support/DataTest.php
@@ -1,0 +1,185 @@
+<?php
+
+use Hybridly\PropertiesResolver\RequestPropertiesResolver;
+
+use function Hybridly\Testing\partial_headers;
+
+use Hybridly\Tests\Fixtures\Data\DataObjectWithLazyProperty;
+use Illuminate\Http\Request;
+use Spatie\LaravelData\Lazy;
+
+function resolve_properties(array $properties, array $headers = [], array $persisted = [], bool $partial = false, array $only = null, array $except = null): array
+{
+    $component = 'test-component';
+    $request = Request::createFrom(request());
+    $request->headers->add([
+        ...$headers,
+        ...($partial ? partial_headers($component, $only, $except) : []),
+    ]);
+
+    /** @var RequestPropertiesResolver */
+    $resolver = resolve(RequestPropertiesResolver::class, [
+        'request' => $request,
+    ]);
+
+    return $resolver->resolve($component, $properties, $persisted);
+}
+
+test('partial properties in data objects are ignored like normal partial properties', function () {
+    $properties = resolve_properties([
+        'data' => DataObjectWithLazyProperty::from([
+            'foo' => true,
+            'bar' => Lazy::partial(fn () => 'baz'),
+        ]),
+    ], partial: false);
+
+    expect($properties)->toBe([
+        'data' => [
+            'foo' => true,
+        ],
+    ]);
+});
+
+test('partial properties in data objects are resolved when using partial reloads', function () {
+    $properties = resolve_properties([
+        'data' => DataObjectWithLazyProperty::from([
+            'foo' => true,
+            'bar' => Lazy::partial(fn () => 'baz'),
+        ]),
+    ], partial: true);
+
+    expect($properties)->toBe([
+        'data' => [
+            'foo' => true,
+            'bar' => 'baz',
+        ],
+    ]);
+});
+
+test('partial properties in data objects are ignored when excluded in partial reloads', function () {
+    $properties = resolve_properties([
+        'data' => DataObjectWithLazyProperty::from([
+            'foo' => true,
+            'bar' => Lazy::partial(fn () => 'baz'),
+        ]),
+    ], except: ['data'], partial: true);
+
+    expect($properties)->toBeEmpty();
+});
+
+test('partial properties in data objects are ignored when excluded with dot notation in partial reloads', function () {
+    $properties = resolve_properties([
+        'data' => DataObjectWithLazyProperty::from([
+            'foo' => true,
+            'bar' => Lazy::partial(fn () => 'baz'),
+        ]),
+    ], except: ['data.bar'], partial: true);
+
+    expect($properties)->toBe([
+        'data' => [
+            'foo' => true,
+        ],
+    ]);
+
+    $properties = resolve_properties([
+        'data' => DataObjectWithLazyProperty::from([
+            'foo' => true,
+            'bar' => Lazy::partial(fn () => 'baz'),
+        ]),
+    ], except: ['data.foo'], partial: true);
+
+    expect($properties)->toBe([
+        'data' => [
+            'bar' => 'baz',
+        ],
+    ]);
+});
+
+test('other properties are ignored when only some partial properties are specified in data objects during partial reloads', function () {
+    $properties = resolve_properties([
+        'data' => DataObjectWithLazyProperty::from([
+            'foo' => true,
+            'bar' => Lazy::partial(fn () => 'baz'),
+        ]),
+    ], only: ['data.bar'], partial: true);
+
+    expect($properties)->toBe([
+        'data' => [
+            'bar' => 'baz',
+        ],
+    ]);
+});
+
+test('properties using lazy closures are resolved', function () {
+    $properties = resolve_properties([
+        'data' => DataObjectWithLazyProperty::from([
+            'foo' => true,
+            'bar' => Lazy::closure(fn () => 'baz'),
+        ]),
+    ], partial: false);
+
+    expect($properties)->toBe([
+        'data' => [
+            'foo' => true,
+            'bar' => 'baz',
+        ],
+    ]);
+});
+
+test('properties using lazy closures are resolved during partial reloads', function () {
+    $properties = resolve_properties([
+        'data' => DataObjectWithLazyProperty::from([
+            'foo' => true,
+            'bar' => Lazy::closure(fn () => 'baz'),
+        ]),
+    ], partial: true);
+
+    expect($properties)->toBe([
+        'data' => [
+            'foo' => true,
+            'bar' => 'baz',
+        ],
+    ]);
+});
+
+test('properties using lazy closures are not evaluated when exluded during partial reloads', function () {
+    $evaluated = false;
+    $properties = resolve_properties([
+        'data' => DataObjectWithLazyProperty::from([
+            'foo' => true,
+            'bar' => Lazy::closure(function () use (&$evaluated) {
+                $evaluated = true;
+
+                return 'baz';
+            }),
+        ]),
+    ], except: ['data.bar'], partial: true);
+
+    expect($evaluated)->toBeFalse();
+    expect($properties)->toBe([
+        'data' => [
+            'foo' => true,
+        ],
+    ]);
+});
+
+test('properties using lazy partials are not evaluated when exluded during partial reloads', function () {
+    $evaluated = false;
+    $properties = resolve_properties([
+        'data' => DataObjectWithLazyProperty::from([
+            'foo' => true,
+            'bar' => Lazy::partial(function () use (&$evaluated) {
+                $evaluated = true;
+
+                return 'baz';
+            }),
+        ]),
+    ], except: ['data.bar'], partial: true);
+
+    expect($evaluated)->toBeFalse();
+    expect($properties)->toBe([
+        'data' => [
+            'foo' => true,
+        ],
+    ]);
+});

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -5,6 +5,7 @@ namespace Hybridly\Tests;
 use Hybridly\HybridlyServiceProvider;
 use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Spatie\LaravelData\LaravelDataServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -12,6 +13,7 @@ class TestCase extends Orchestra
     {
         return [
             HybridlyServiceProvider::class,
+            LaravelDataServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
This pull request adds support for lazy and partial properties in data objects (using `laravel-data`). This is possible thanks to https://github.com/spatie/laravel-data/commit/bcb4083ff2a3e2a2331872638cc1b5208f0f3c11 and https://github.com/spatie/laravel-data/commit/eda87c18d6da8ca2f07233f059b3b29e4a7fe56c, so a `laravel-data` version bump is needed.

```php
return SharedData::from([
    'security' => [
        'user' => Lazy::closure(fn () => auth()->user()),
    ],
]);
```

The implementation for converting a property tree into a traversable array slightly changed:

- Before, nested properties in special objects could not be included or excluded using the dot-notation since the property tree conversion was done *after* the inclusion/exclusion
- Now, the property tree is made traversable before the property inclusion/exclusion so properties in special objects can be handled
- Now, a second traversal of the property tree is made after the inclusion/exclusion to evaluate lazy properties
- Properties are still only evaluated at the end of the resolution, so if a lazy property contains a nested array, it still cannot be included/excluded in partial reloads

