### PR TITLE
fix(forms): transform dot-notated errors to nested objects

### DIFF
--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -238,6 +238,4 @@ export interface Progress {
 	percentage: Readonly<number>
 }
 
-export interface Errors {
-	[key: string]: string
-}
+export type Errors = any

--- a/packages/utils/src/utils.spec.ts
+++ b/packages/utils/src/utils.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { setValueAtPath, unsetPropertyAtPath } from './utils'
+
+describe('utils', () => {
+	it('sets a value at a path in an object', () => {
+		const obj = {}
+		setValueAtPath(obj, 'foo.bar.baz', 'qux')
+		expect(obj).toEqual({ foo: { bar: { baz: 'qux' } } })
+	})
+
+	it('unsets a property at a path in an object', () => {
+		const obj = {
+			foo: {
+				bar: 'bar',
+				baz: 'baz',
+			},
+		}
+		unsetPropertyAtPath(obj, 'foo.bar')
+		expect(obj).toEqual({
+			foo: {
+				baz: 'baz',
+			},
+		})
+	})
+
+	it('deletes empty objects along the way when unsetting a property at a path in an object', () => {
+		const obj = {
+			foo: {
+				bar: {
+					baz: 'baz',
+				},
+			},
+		}
+		unsetPropertyAtPath(obj, 'foo.bar.baz')
+		expect(obj).toEqual({})
+	})
+})

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -86,3 +86,64 @@ export function merge<T>(x: Partial<T>, y: Partial<T>, options: MergeOptions = {
 export function removeTrailingSlash(string: string): string {
 	return string.replace(/\/+$/, '')
 }
+
+/**
+ * Sets a value at a path in an object
+ *
+ * This function will set a value at a path in an object, creating any missing
+ * objects along the way. The object is modified in place.
+ *
+ * @param obj the object to set the value in
+ * @param path a dot-separated path to the property to set
+ * @param value the value to set
+ */
+export function setValueAtPath(obj: any, path: string, value: any): void {
+	// If the path doesn't contain a dot, then we can just set the value.
+	if (!path.includes('.')) {
+		obj[path] = value
+		return
+	}
+
+	// Otherwise, we need to split the path into segments and walk down the
+	// object tree until we find the right place to set the value.
+	const segments = path.split('.')
+	let nestedObject = obj
+	for (let i = 0; i < segments.length - 1; i++) {
+		const key = segments[i]
+		nestedObject = nestedObject[key] = nestedObject[key] || {}
+	}
+	nestedObject[segments[segments.length - 1]] = value
+}
+
+/**
+ * Unsets a property at a path in an object
+ *
+ * This function will unset a property at a path in an object, deleting any
+ * objects along the way that are empty. The object is modified in place.
+ *
+ * @param obj the object to unset the property in
+ * @param path a dot-separated path to the property to unset
+ */
+export function unsetPropertyAtPath(obj: any, path: string): void {
+	// If the path doesn't contain a dot, then we can just delete the property.
+	if (!path.includes('.')) {
+		delete obj[path]
+		return
+	}
+
+	// Otherwise, we need to split the path into segments and walk down the
+	// object tree until we find the right place to delete the property.
+	const segments = path.split('.')
+	let nestedObject = obj
+	for (let i = 0; i < segments.length - 1; i++) {
+		const key = segments[i]
+		nestedObject = nestedObject[key] = nestedObject[key] || {}
+	}
+
+	delete nestedObject[segments[segments.length - 1]]
+
+	// If the nested object is now empty, delete it.
+	if (Object.keys(nestedObject).length === 0) {
+		unsetPropertyAtPath(obj, segments.slice(0, -1).join('.'))
+	}
+}

--- a/packages/vue/src/composables/form.ts
+++ b/packages/vue/src/composables/form.ts
@@ -205,13 +205,29 @@ export function useForm<T extends Fields = Fields>(options: FormOptions<T>) {
 		delete errors.value[key]
 	}
 
+	function setNestedValue(obj: any, path: string, value: any) {
+		const segments = path.split('.')
+		let nestedObject = obj
+		for (let i = 0; i < segments.length - 1; i++) {
+			const key = segments[i]
+			nestedObject = nestedObject[key] = nestedObject[key] || {}
+		}
+		nestedObject[segments[segments.length - 1]] = value
+	}
+
 	/**
 	 * Sets current errors.
 	 */
 	function setErrors(incoming: Record<string, string>) {
 		clearErrors()
 		Object.entries(incoming).forEach(([key, value]) => {
-			errors.value[key as keyof T] = value as any
+			// if the key is a dot-notated path, we expand it to set the error
+			// on the correct field
+			if (key.includes('.')) {
+				setNestedValue(errors.value, key, value)
+			} else {
+				errors.value[key] = value
+			}
 		})
 	}
 

--- a/packages/vue/src/composables/form.ts
+++ b/packages/vue/src/composables/form.ts
@@ -4,11 +4,17 @@ import type { DeepReadonly } from 'vue'
 import { computed, reactive, ref, toRaw, watch } from 'vue'
 import { clone, setValueAtPath, unsetPropertyAtPath } from '@hybridly/utils'
 import { router } from '@hybridly/core'
+import type { Path, SearchableObject } from '@clickbar/dot-diver'
+import { getByPath } from '@clickbar/dot-diver'
 import { state } from '../stores/state'
 
-type Fields = Record<string, any>
+type Errors<T extends SearchableObject> = {
+	[K in keyof T]?: T[K] extends Record<string, any>
+		? Errors<T[K]>
+		: string;
+}
 
-interface FormOptions<T extends Fields> extends Omit<HybridRequestOptions, 'data' | 'url'> {
+interface FormOptions<T extends SearchableObject> extends Omit<HybridRequestOptions, 'data' | 'url'> {
 	fields: T
 	url?: UrlResolvable | (() => UrlResolvable)
 	key?: string | false
@@ -29,14 +35,17 @@ interface FormOptions<T extends Fields> extends Omit<HybridRequestOptions, 'data
 	/**
 	 * Callback executed before the form submission for transforming the fields.
 	 */
-	transform?: (fields: T) => Fields
+	transform?: (fields: T) => any
 }
 
 function safeClone<T>(obj: T): T {
 	return clone(toRaw(obj))
 }
 
-export function useForm<T extends Fields = Fields>(options: FormOptions<T>) {
+export function useForm<
+	T extends SearchableObject,
+	P extends Path<T> & string = Path<T> & string
+>(options: FormOptions<T>) {
 	// https://github.com/hybridly/hybridly/issues/23
 	// TODO: explore unique/automatic key generation
 	const shouldRemember = !!options?.key
@@ -52,9 +61,9 @@ export function useForm<T extends Fields = Fields>(options: FormOptions<T>) {
 	/** Fields as they were when loaded. */
 	const loaded = safeClone(historyData?.fields ?? options.fields)
 	/** Current fields. */
-	const fields = reactive<T>(safeClone(loaded))
+	const fields = reactive<T>(safeClone(loaded)) as T
 	/** Validation errors for each field. */
-	const errors = ref<Record<keyof T, string>>(historyData?.errors ?? {})
+	const errors = ref<Errors<T>>(historyData?.errors ?? {})
 	/** Whether the form is dirty. */
 	const isDirty = ref(false)
 	/** Whether the submission was recently successful. */
@@ -82,9 +91,9 @@ export function useForm<T extends Fields = Fields>(options: FormOptions<T>) {
 	/**
 	 * Resets the form to its initial values.
 	 */
-	function reset(...keys: (keyof T)[]) {
+	function reset(...keys: P[]) {
 		if (keys.length === 0) {
-			keys = Object.keys(fields)
+			keys = Object.keys(fields) as P[]
 		}
 
 		keys.forEach((key) => {
@@ -95,9 +104,9 @@ export function useForm<T extends Fields = Fields>(options: FormOptions<T>) {
 	/**
 	 * Clear the form fields.
 	 */
-	function clear(...keys: (keyof T)[]) {
+	function clear(...keys: P[]) {
 		if (keys.length === 0) {
-			keys = Object.keys(fields)
+			keys = Object.keys(fields) as P[]
 		}
 
 		keys.forEach((key) => {
@@ -177,9 +186,9 @@ export function useForm<T extends Fields = Fields>(options: FormOptions<T>) {
 	/**
 	 * Clears all errors.
 	 */
-	function clearErrors(...keys: string[]) {
+	function clearErrors(...keys: P[]) {
 		if (keys.length === 0) {
-			keys = Object.keys(fields)
+			keys = Object.keys(fields) as P[]
 		}
 
 		keys.forEach((key) => {
@@ -190,25 +199,25 @@ export function useForm<T extends Fields = Fields>(options: FormOptions<T>) {
 	/**
 	 * Checks if the given keys are dirty in the form.
 	 */
-	function hasDirty(...keys: (keyof T)[]) {
+	function hasDirty(...keys: P[]) {
 		if (keys.length === 0) {
 			return isDirty.value
 		}
 
-		return keys.some((key) => !isEqual(toRaw(fields[key]), toRaw(initial[key])))
+		return keys.some((key) => !isEqual(toRaw(getByPath(fields, key)), toRaw(getByPath(initial, key))))
 	}
 
 	/**
 	 * Clears the given field's error.
 	 */
-	function clearError(key: string) {
+	function clearError(key: P) {
 		unsetPropertyAtPath(errors.value, key)
 	}
 
 	/**
 	 * Sets current errors.
 	 */
-	function setErrors(incoming: Record<string, string>) {
+	function setErrors(incoming: Errors<T>) {
 		clearErrors()
 		Object.entries(incoming).forEach(([path, value]) => {
 			setValueAtPath(errors.value, path, value)


### PR DESCRIPTION
This PR is an attempt at fixing #71.

---

This PR updates the `setErrors`, `clearError` and `clearErrors` functions exposed by the `useForm` composable.

### `setErrors`

`setErrors` now expands dot-notated error keys and places the error message in an object structure that follows the structure of the form's fields. This change does not impact simple forms that do not use nesting, and they'll continue working as is.

#### Current behaviour
Assuming that all fields of the following form are required.

```ts
const form = useForm({
    url: '/test',
    method: 'POST',
    fields: {
        name: '',
        phone: {
            work: ''
        }
    }
})
```

The errors returned by Laravel would be:

```json
{
  "name": "The name field is required.",
  "phone.work": "The phone.work field is required."
}
```

and the error object tracked by Hybridly would be:

```json
{
  "name": "The name field is required.",
  "phone.work": "The phone.work field is required."
}
```

#### New behaviour

`setErrors` expands the dot-notated keys and sets the error message in the correct place.

The errors returned by Laravel are the same:

```json
{
  "name": "The name field is required.",
  "phone.work": "The phone.work field is required."
}
```

But the errors tracked by Hybridly become:

```json
{
  "name": "The name field is required.",
  "phone": {
    "work": "The phone.work field is required."
  }
}
```

### `clearError`

`clearError` now accepts a dot-notated path to the error to clear.

```ts
const form = useForm({
    url: '/test',
    method: 'POST',
    fields: {
        name: '',
        phone: {
            work: ''
        }
    }
})

form.clearError('phone.work')
```

When clearing an error, if the parent object is left empty (no more errors), the parent object is also cleared. In this example, the `phone` object will be cleared if the `work` error has been cleared.

---

Two new `setValueAtPath` and `unsetPropertyAtPath` utilities have been created and tests have been created for them.