### PR TITLE
fix(architecture): properly compute relative file paths on Windows

### DIFF
--- a/packages/laravel/src/Support/VueViewFinder.php
+++ b/packages/laravel/src/Support/VueViewFinder.php
@@ -169,7 +169,7 @@ final class VueViewFinder
                 if (str($path)->endsWith($this->extensions)) {
                     $files[] = [
                         'namespace' => $namespace,
-                        'path' => str_replace(base_path(DIRECTORY_SEPARATOR), '', $path),
+                        'path' => str_replace(base_path(\DIRECTORY_SEPARATOR), '', $path),
                         'identifier' => $this->getIdentifier($path, $baseDirectory, $namespace),
                     ];
                 }

--- a/packages/laravel/src/Support/VueViewFinder.php
+++ b/packages/laravel/src/Support/VueViewFinder.php
@@ -169,7 +169,7 @@ final class VueViewFinder
                 if (str($path)->endsWith($this->extensions)) {
                     $files[] = [
                         'namespace' => $namespace,
-                        'path' => str_replace(base_path('/'), '', $path),
+                        'path' => str_replace(base_path(DIRECTORY_SEPARATOR), '', $path),
                         'identifier' => $this->getIdentifier($path, $baseDirectory, $namespace),
                     ];
                 }


### PR DESCRIPTION
On Windows, `vue` files are not properly parsed due to the hardcoded forward slash `/` in the vue files finder, a proper fix is to use the `DIRECTORY_SEPARATOR` instead.