### PR TITLE
ci: bump `pnpm/action-setup` to `2.2.4`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
+        uses: pnpm/action-setup@v2.2.4
         with:
           version: 8.6.1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
+        uses: pnpm/action-setup@v2.2.4
         with:
           version: 8.6.1
 


### PR DESCRIPTION
This PR:

- [x] Bumps `pnpm/action-setup` to `v2.2.4` to remove the GitHub Actions warnings related to `save-state`.

https://github.com/hybridly/hybridly/actions/runs/5337303313/jobs/9673163709#step:3:9