### PR TITLE
chore(deps): bump pnpm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2.0.1
         with:
-          version: 8.6.1
+          version: 8.6.3
 
       - name: Use Node.js v16
         uses: actions/setup-node@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2.0.1
         with:
-          version: 8.6.1
+          version: 8.6.3
 
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "docs:serve": "vitepress serve docs",
         "ci": "pnpm run lint && pnpm run build && pnpm run test"
     },
-    "packageManager": "pnpm@7.13.4",
+    "packageManager": "pnpm@8.6.3",
     "devDependencies": {
         "@fontsource-variable/rubik": "^5.0.2",
         "@hybridly/core": "workspace:*",


### PR DESCRIPTION
This PR:

- [x] Update the `packageManager` field to use the latest pnpm version (`8.6.3`).
- [x] Updates the pnpm version used in the CI so that it matches the version in `packageManager`