### PR TITLE
docs: add note about lowercase component identifiers

### DIFF
--- a/docs/api/laravel/hybridly.md
+++ b/docs/api/laravel/hybridly.md
@@ -8,6 +8,10 @@ Generates a `HybridResponse` with the given component and optional properties. T
 
 > See [responses](../../guide/responses.md) for more details.
 
+:::info Notes
+- Component names will only use lowercase names, so if you have a `Dashboard.vue` page component, please make sure to use `hybridly('dashboard')`.
+:::
+
 ### Usage
 
 ```php

--- a/docs/guide/upgrade/0.4.x.md
+++ b/docs/guide/upgrade/0.4.x.md
@@ -44,6 +44,15 @@ return view('security::login'); // [!code ++]
 ```
 :::
 
+Additionally you also need to update all page component identifiers to lowercase:
+
+:::code-group
+```php [Views]
+return view('Dashboard'); // [!code --]
+return view('dashboard'); // [!code ++]
+```
+:::
+
 ## Updating `config/hybridly.php`
 
 - **Likelihood of impact**: <span class="text-green-700 dark:text-green-300">low</span>


### PR DESCRIPTION
As the title says, and we discussed in Discord,
here i added a little note to the upgrade guide and
the view function documentation about using lowercase
identifiers only.