### PR TITLE
chore(deps): update `laravel-vite-plugin`

### DIFF
--- a/docs/configuration/vite.md
+++ b/docs/configuration/vite.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Vite plugin, in addition to providing Hybridly-specific features, wraps a few external Vite plugins that are often needed in single-page applications. 
+The Vite plugin, in addition to providing Hybridly-specific features, wraps a few external Vite plugins that are often needed in single-page applications.
 
 These plugins are provided with a good default configuration, but are still individually configurable.
 
@@ -20,7 +20,7 @@ export default defineConfig({
 	plugins: [
 		hybridly({ // [!code focus:5]
 			laravel: {
-				valetTls: true,
+				detectTls: true,
 			},
 		}),
 	],

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -82,7 +82,7 @@ export default defineConfig({
 	plugins: [
 		hybridly({
 			laravel: {
-				valetTls: true
+				detectTls: true
 			}
 		}),
 	],
@@ -208,14 +208,14 @@ export default defineConfig({
 	plugins: [
 		hybridly({
 			laravel: {
-				valetTls: true
+				detectTls: true
 			}
 		}),
 	],
 })
 ```
 
-If you add `valetTls`, which you should, don't forget to also run `valet secure` and set up `APP_URL` in `.env`.
+If you add `detectTls`, which you should, don't forget to also run `valet secure` and set up `APP_URL` in `.env`.
 
 ### Initialize Hybridly
 

--- a/docs/guide/upgrade/0.1.x.md
+++ b/docs/guide/upgrade/0.1.x.md
@@ -32,13 +32,13 @@ Previously, the expected emplacement for both page components and layouts was in
 The function that initializes Hybridly was previously exported by `hybridly/vue`. To simplify the setup, it is now exported by a virtual import, so the `pages` options is no longer needed.
 
 ```ts
-import { initializeHybridly } from "virtual:hybridly/config"; // [!code ++]
-import { initializeHybridly } from "hybridly/vue"; // [!code --]
-import "virtual:hybridly/router"; // [!code --]
+import { initializeHybridly } from 'virtual:hybridly/config' // [!code ++]
+import { initializeHybridly } from 'hybridly/vue' // [!code --]
+import 'virtual:hybridly/router' // [!code --]
 
 initializeHybridly({
-	pages: import.meta.glob("@/domains/**/pages/**/*.vue", { eager: true }), // [!code --]
-});
+	pages: import.meta.glob('@/domains/**/pages/**/*.vue', { eager: true }), // [!code --]
+})
 ```
 
 The `pages` option is automatically setup according to the optional `hybridly.config.ts` configuration file. To enable or disable eager-loading of page components, you may use the `eager` option in that file.
@@ -52,10 +52,10 @@ The Vite plugin now registers `laravel-vite-plugin`, `@vitejs/plugin-vue`, `vite
 You may remove all of them from `vite.config.ts` and configure them individually through the options of `hybridly`:
 
 ```ts
-import path from "node:path";
-import hybridly from "hybridly/vite";
-import { defineConfig } from "vite";
-import { HeadlessUiResolver } from "unplugin-vue-components/resolvers";
+import path from 'node:path'
+import hybridly from 'hybridly/vite'
+import { defineConfig } from 'vite'
+import { HeadlessUiResolver } from 'unplugin-vue-components/resolvers'
 
 export default defineConfig({
 	plugins: [
@@ -63,7 +63,7 @@ export default defineConfig({
 			laravel: {
 				detectTls: true,
 			},
-			customIcons: ["aircraft"], // registers icons in `resources/icons/aircraft`
+			customIcons: ['aircraft'], // registers icons in `resources/icons/aircraft`
 		}),
 	],
 });
@@ -115,11 +115,11 @@ Additionally, since PHP cannot read `hybridly.config.ts`, `testing.page_paths` s
 If you were using a domain-based architecture, you will now need to indicate that to Hybridly by creating `hybridly.config.ts` and setting `domains` to `true`:
 
 ```ts
-import { defineConfig } from "hybridly/config";
+import { defineConfig } from 'hybridly/config'
 
 export default defineConfig({
 	domains: true,
-});
+})
 ```
 
 You may read more about the options available in the configuration section.

--- a/docs/guide/upgrade/0.1.x.md
+++ b/docs/guide/upgrade/0.1.x.md
@@ -32,13 +32,13 @@ Previously, the expected emplacement for both page components and layouts was in
 The function that initializes Hybridly was previously exported by `hybridly/vue`. To simplify the setup, it is now exported by a virtual import, so the `pages` options is no longer needed.
 
 ```ts
-import { initializeHybridly } from 'virtual:hybridly/config' // [!code ++]
-import { initializeHybridly } from 'hybridly/vue' // [!code --]
-import 'virtual:hybridly/router' // [!code --]
+import { initializeHybridly } from "virtual:hybridly/config"; // [!code ++]
+import { initializeHybridly } from "hybridly/vue"; // [!code --]
+import "virtual:hybridly/router"; // [!code --]
 
 initializeHybridly({
-	pages: import.meta.glob('@/domains/**/pages/**/*.vue', { eager: true }), // [!code --]
-})
+	pages: import.meta.glob("@/domains/**/pages/**/*.vue", { eager: true }), // [!code --]
+});
 ```
 
 The `pages` option is automatically setup according to the optional `hybridly.config.ts` configuration file. To enable or disable eager-loading of page components, you may use the `eager` option in that file.
@@ -52,21 +52,21 @@ The Vite plugin now registers `laravel-vite-plugin`, `@vitejs/plugin-vue`, `vite
 You may remove all of them from `vite.config.ts` and configure them individually through the options of `hybridly`:
 
 ```ts
-import path from 'node:path'
-import hybridly from 'hybridly/vite'
-import { defineConfig } from 'vite'
-import { HeadlessUiResolver } from 'unplugin-vue-components/resolvers'
+import path from "node:path";
+import hybridly from "hybridly/vite";
+import { defineConfig } from "vite";
+import { HeadlessUiResolver } from "unplugin-vue-components/resolvers";
 
 export default defineConfig({
 	plugins: [
 		hybridly({
 			laravel: {
-				valetTls: true,
+				detectTls: true,
 			},
-			customIcons: ['aircraft'], // registers icons in `resources/icons/aircraft`
+			customIcons: ["aircraft"], // registers icons in `resources/icons/aircraft`
 		}),
-	]
-})
+	],
+});
 ```
 
 These plugins can also be removed from `package.json`. If you need to register resolvers from `unplugin-vue-components`, you still need to have it installed.
@@ -79,7 +79,7 @@ You may read more about the configuration of all included plugins in the [config
 
 - **Likelihood of impact**: medium
 
-Hybridly now generates its types and some other files in a root-level `.hybridly` directory. This directory needs to be ignored from Git because the files in it changes often and are generated when the development server starts. 
+Hybridly now generates its types and some other files in a root-level `.hybridly` directory. This directory needs to be ignored from Git because the files in it changes often and are generated when the development server starts.
 
 ```gitignore
 /public/build
@@ -91,12 +91,11 @@ resources/types/*.d.ts // [!code --]
 
 If you were ignoring files in `resources/types`, you may also delete this directory and remove it from `.gitignore`.
 
-
 ## Updating `config/hybridly.php`
 
 - **Likelihood of impact**: medium
 
-If you published `config/hybridly.php`, `i18n.locales_path` and `i18n.lang_path` should be removed because they will interfere with their new default values. 
+If you published `config/hybridly.php`, `i18n.locales_path` and `i18n.lang_path` should be removed because they will interfere with their new default values.
 
 Additionally, since PHP cannot read `hybridly.config.ts`, `testing.page_paths` should be updated accordingly:
 
@@ -116,11 +115,11 @@ Additionally, since PHP cannot read `hybridly.config.ts`, `testing.page_paths` s
 If you were using a domain-based architecture, you will now need to indicate that to Hybridly by creating `hybridly.config.ts` and setting `domains` to `true`:
 
 ```ts
-import { defineConfig } from 'hybridly/config'
+import { defineConfig } from "hybridly/config";
 
 export default defineConfig({
 	domains: true,
-})
+});
 ```
 
 You may read more about the options available in the configuration section.

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -46,7 +46,7 @@
         "@hybridly/core": "workspace:*",
         "@vitejs/plugin-vue": "^4.2.3",
         "fast-glob": "^3.3.0",
-        "laravel-vite-plugin": "^0.7.8",
+        "laravel-vite-plugin": "^0.8.0",
         "local-pkg": "^0.4.3",
         "throttle-debounce": "^5.0.0",
         "unplugin-auto-import": "^0.16.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       laravel-vite-plugin:
-        specifier: ^0.7.8
-        version: 0.7.8(vite@4.4.3)
+        specifier: ^0.8.0
+        version: 0.8.0(vite@4.4.3)
       local-pkg:
         specifier: ^0.4.3
         version: 0.4.3
@@ -580,6 +580,7 @@ packages:
   /@babel/highlight@7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
+    requiresBuild: true
     dependencies:
       '@babel/helper-validator-identifier': 7.19.1
       chalk: 2.4.2
@@ -2182,6 +2183,7 @@ packages:
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       color-convert: 1.9.3
     dev: true
@@ -2440,6 +2442,7 @@ packages:
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
@@ -2539,6 +2542,7 @@ packages:
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    requiresBuild: true
     dependencies:
       color-name: 1.1.3
     dev: true
@@ -2552,6 +2556,7 @@ packages:
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    requiresBuild: true
     dev: true
 
   /color-name@1.1.4:
@@ -4134,6 +4139,7 @@ packages:
   /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dev: true
 
   /has-flag@4.0.0:
@@ -4511,6 +4517,7 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    requiresBuild: true
     dev: true
 
   /js-yaml@4.1.0:
@@ -4590,8 +4597,8 @@ packages:
   /kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
-  /laravel-vite-plugin@0.7.8(vite@4.4.3):
-    resolution: {integrity: sha512-HWYqpQYHR3kEQ1LsHX7gHJoNNf0bz5z5mDaHBLzS+PGLCTmYqlU5/SZyeEgObV7z7bC/cnStYcY9H1DI1D5Udg==}
+  /laravel-vite-plugin@0.8.0(vite@4.4.3):
+    resolution: {integrity: sha512-6VjLI+azBpeK6rWBiKcb/En5GnTdYpL0U4zS8gXYvb2/VSq4mlau5H3NWpSktUDBMM1b97LLgICx5zevi8IY0w==}
     engines: {node: '>=14'}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
@@ -5821,6 +5828,7 @@ packages:
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       has-flag: 3.0.0
     dev: true


### PR DESCRIPTION
This PR:

- [x] Bumps `laravel-vite-plugin` to `0.8.0` to add support for Herd 
- [x] Updates the documentation to replace `valetTls` (now deprecated) occurrences by `detectTls`.

Related:
- https://github.com/laravel/vite-plugin/pull/233

---

Side note: maybe we could make `laravel-vite-plugin` a peer dependency.