### PR TITLE
feat: properties-only responses

### DIFF
--- a/docs/api/laravel/functions.md
+++ b/docs/api/laravel/functions.md
@@ -54,6 +54,18 @@ use function Hybridly\view;
 return view('user.show', $user);
 ```
 
+### `properties`
+
+Returns updated properties for an existing view. This is the same as calling [`hybridly()->properties()`](./hybridly.md#properties).
+
+```php
+use function Hybridly\properties;
+
+return properties([
+	'user' => $user,
+]);
+```
+
 ### `partial`
 
 Creates a [partial-only](../../guide/partial-reloads.md#partial-only-properties) property. This is the same as calling [`hybridly()->partial()`](./hybridly.md#partial).

--- a/docs/api/laravel/hybridly.md
+++ b/docs/api/laravel/hybridly.md
@@ -16,6 +16,20 @@ return hybridly('users.show', [
 ]);
 ```
 
+## `properties`
+
+Generates a `HybridResponse` with the given properties. The properties can be an array, an `Arrayable` or a data object.
+
+> See [responses](../../guide/responses.md#updating-properties) for more details.
+
+### Usage
+
+```php
+return hybridly()->properties([
+  'user' => UserData::from($user)
+]);
+```
+
 ## `base`
 
 Makes the view a [dialog](../../guide/dialogs.md) and defines its base page. It takes a route name and its parameters as its arguments.

--- a/docs/guide/responses.md
+++ b/docs/guide/responses.md
@@ -41,6 +41,36 @@ defineProps<{ // [!code focus:3]
 Since paginators are so common, Hybridly provides typings for them. You don't need any setup, the `Paginator` type is global. When using paginators without a `meta` property, you may use `UnwrappedPaginator` instead.
 :::
 
+## Updating properties
+
+It is a common pattern to have a `POST` or `PUT` hybrid request that ends up redirecting back to the previous page, which essentially refreshes the properties of the page to avoid having stale data.
+
+```php
+public function store(UpdateUserRequest $request): HybridResponse
+{
+    User::update($request->validate());
+
+    return back();
+}
+```
+
+Such a redirection, though, implies an additional server round-trip and the re-execution of the server-side controller responsible for the view, which may slow down the response.
+
+Instead, you may return only properties from the `POST` or `PUT` controller:
+
+```php
+public function store(UpdateUserRequest $request): HybridResponse
+{
+    $user = User::update($request->validate());
+
+    return hybridly(properties: [
+        'user' => $user,
+    ]);
+}
+```
+
+In that situation, the returned properties will be merged with the current ones, similarly to what happens during a [partial reload](./partial-reloads.md).
+
 ## Internal redirects
 
 When making non-get hybrid requests, you may use redirects to a standard `GET` hybrid endpoint. Hybridly will follow the redirect and update the page accordingly.

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -178,12 +178,12 @@ export interface PendingNavigation {
 /** A page or dialog component. */
 export interface View {
 	/** Name of the component to use. */
-	component: string
+	component?: string
 	/** Properties to apply to the component. */
 	properties: Properties
 }
 
-export interface Dialog extends View {
+export interface Dialog extends Required<View> {
 	/** URL that is the base background page when navigating to the dialog directly. */
 	baseUrl: string
 	/** URL to which the dialog should redirect when closed. */

--- a/packages/laravel/src/Hybridly.php
+++ b/packages/laravel/src/Hybridly.php
@@ -43,6 +43,16 @@ final class Hybridly
     }
 
     /**
+     * Returns updated properties for the current view.
+     *
+     * @see https://hybridly.dev/api/laravel/hybridly.html#properties
+     */
+    public function properties(array|Arrayable|DataObject $properties): Factory
+    {
+        return resolve(Factory::class)->properties($properties);
+    }
+
+    /**
      * Generates a response for redirecting to an external website, or a non-hybrid page.
      * This can also be used to redirect to a hybrid page when it is not known whether the current request is hybrid or not.
      *

--- a/packages/laravel/src/Hybridly.php
+++ b/packages/laravel/src/Hybridly.php
@@ -37,7 +37,7 @@ final class Hybridly
      *
      * @see https://hybridly.dev/api/laravel/hybridly.html#view
      */
-    public function view(string $component, array|Arrayable|DataObject $properties = []): Factory
+    public function view(string $component = null, array|Arrayable|DataObject $properties = []): Factory
     {
         return resolve(Factory::class)->view($component, $properties);
     }

--- a/packages/laravel/src/Support/MissingViewComponentException.php
+++ b/packages/laravel/src/Support/MissingViewComponentException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Hybridly\Support;
+
+use Exception;
+
+final class MissingViewComponentException extends Exception
+{
+    public static function make(): static
+    {
+        return new static('The view component is missing but is required for initial page loads.');
+    }
+}

--- a/packages/laravel/src/Support/PropertiesResolver.php
+++ b/packages/laravel/src/Support/PropertiesResolver.php
@@ -15,9 +15,11 @@ final class PropertiesResolver
     ) {
     }
 
-    public function resolve(string $component, array $properties, array $persisted): array
+    public function resolve(string $component = null, array $properties = [], array $persisted = []): array
     {
-        $partial = $this->request->header(Header::PARTIAL_COMPONENT) === $component;
+        $partial = \is_null($component)
+            ? $this->request->headers->has(Header::PARTIAL_COMPONENT)
+            : $this->request->header(Header::PARTIAL_COMPONENT) === $component;
 
         if (!$partial) {
             $properties = Arr::filterRecursive($properties, static fn ($property) => !($property instanceof Partial));

--- a/packages/laravel/src/Support/global_helpers.php
+++ b/packages/laravel/src/Support/global_helpers.php
@@ -18,7 +18,7 @@ if (!function_exists('hybridly')) {
         /** @var Hybridly */
         $hybridly = resolve(Hybridly::class);
 
-        if (!is_null($component)) {
+        if (!is_null($component) || !empty($properties)) {
             return $hybridly->view($component, $properties);
         }
 

--- a/packages/laravel/src/Support/helpers.php
+++ b/packages/laravel/src/Support/helpers.php
@@ -52,7 +52,7 @@ if (!\function_exists('Hybridly\properties')) {
      *
      * @see https://hybridly.dev/api/laravel/functions.html#properties
      */
-    function view(array|Arrayable|DataObject $properties): Factory
+    function properties(array|Arrayable|DataObject $properties): Factory
     {
         return resolve(Hybridly::class)->properties($properties);
     }

--- a/packages/laravel/src/Support/helpers.php
+++ b/packages/laravel/src/Support/helpers.php
@@ -46,6 +46,18 @@ if (!\function_exists('Hybridly\view')) {
     }
 }
 
+if (!\function_exists('Hybridly\properties')) {
+    /**
+     * Returns properties for an existing view.
+     *
+     * @see https://hybridly.dev/api/laravel/functions.html#properties
+     */
+    function view(array|Arrayable|DataObject $properties): Factory
+    {
+        return resolve(Hybridly::class)->properties($properties);
+    }
+}
+
 if (!\function_exists('Hybridly\partial')) {
     /**
      * Creates a partial-only property.

--- a/packages/laravel/src/View/Factory.php
+++ b/packages/laravel/src/View/Factory.php
@@ -56,13 +56,9 @@ class Factory implements HybridResponse
      */
     public function view(string $component = null, array|Arrayable|DataObject $properties = []): static
     {
-        if ($properties instanceof Arrayable || $properties instanceof DataObject) {
-            $properties = $properties->toArray();
-        }
-
         $this->view = new View(
             component: $component,
-            properties: $properties,
+            properties: $this->transformProperties($properties),
         );
 
         return $this;
@@ -88,7 +84,7 @@ class Factory implements HybridResponse
     {
         $this->view = new View(
             component: $this->view?->component,
-            properties: $properties,
+            properties: $this->transformProperties($properties),
         );
 
         return $this;
@@ -157,6 +153,15 @@ class Factory implements HybridResponse
             view: $this->hybridly->getRootView(),
             data: ['payload' => $payload->toArray()],
         );
+    }
+
+    protected function transformProperties(array|Arrayable|DataObject $properties): array
+    {
+        if ($properties instanceof Arrayable || $properties instanceof DataObject) {
+            $properties = $properties->toArray();
+        }
+
+        return $properties;
     }
 
     protected function renderDialog(Request $request, Payload $payload)

--- a/packages/laravel/src/View/Factory.php
+++ b/packages/laravel/src/View/Factory.php
@@ -6,6 +6,7 @@ use Hybridly\Contracts\HybridResponse;
 use Hybridly\Hybridly;
 use Hybridly\Support\DialogResolver;
 use Hybridly\Support\Header;
+use Hybridly\Support\MissingViewComponentException;
 use Hybridly\Support\PropertiesResolver;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Contracts\Support\Arrayable;
@@ -136,6 +137,12 @@ class Factory implements HybridResponse
             'version' => $this->hybridly->getVersion(),
             'root_view' => $this->hybridly->getRootView(),
         ]]);
+
+        // If the component is missing and there is no page loaded,
+        // throw an exception because the front-end cannot handle that situation.
+        if (!$this->hybridly->isHybrid($request) && !$this->view->component) {
+            throw MissingViewComponentException::make();
+        }
 
         if ($this->hybridly->isHybrid($request)) {
             return new JsonResponse(

--- a/packages/laravel/src/View/Factory.php
+++ b/packages/laravel/src/View/Factory.php
@@ -53,7 +53,7 @@ class Factory implements HybridResponse
     /**
      * Sets the hybridly view data.
      */
-    public function view(string $component, array|Arrayable|DataObject $properties): static
+    public function view(string $component = null, array|Arrayable|DataObject $properties = []): static
     {
         if ($properties instanceof Arrayable || $properties instanceof DataObject) {
             $properties = $properties->toArray();
@@ -85,12 +85,8 @@ class Factory implements HybridResponse
      */
     public function properties(array|Arrayable|DataObject $properties): static
     {
-        if (!isset($this->view)) {
-            throw new \LogicException('The `properties` method requires a view to be defined. Call `view` or `component` before.');
-        }
-
         $this->view = new View(
-            component: $this->view->component,
+            component: $this->view?->component,
             properties: $properties,
         );
 
@@ -189,7 +185,9 @@ class Factory implements HybridResponse
 
         $route = $this->router->getRoutes()->match($request);
 
-        $request->headers->replace($originalRequest->headers->all());
+        /** @var array */
+        $originalHeaders = $originalRequest->headers->all();
+        $request->headers->replace($originalHeaders);
         $request->setJson($originalRequest->json());
         $request->setUserResolver(fn () => $originalRequest->getUserResolver());
         $request->setRouteResolver(fn () => $route);

--- a/packages/laravel/src/View/View.php
+++ b/packages/laravel/src/View/View.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Support\Arrayable;
 class View implements Arrayable
 {
     public function __construct(
-        public string $component,
+        public ?string $component,
         public array $properties,
     ) {
     }

--- a/packages/vue/src/initialize.ts
+++ b/packages/vue/src/initialize.ts
@@ -41,7 +41,10 @@ export async function initializeHybridly(options: InitializeOptions = {}) {
 				state.setContext(context)
 			},
 			onViewSwap: async(options) => {
-				state.setView(options.component)
+				if (options.component) {
+					state.setView(options.component)
+				}
+
 				state.setProperties(options.properties)
 
 				if (!options.preserveState && !options.dialog) {

--- a/tests/src/Laravel/View/FactoryTest.php
+++ b/tests/src/Laravel/View/FactoryTest.php
@@ -2,6 +2,7 @@
 
 use Hybridly\Hybridly;
 use Hybridly\Support\Header;
+use Hybridly\Support\MissingViewComponentException;
 use Hybridly\View\Factory;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -167,3 +168,36 @@ test('the url resolver is used when constructing a response', function () {
         'url' => 'https://customdomain.com/users/makise',
     ]);
 });
+
+test('hybridly responses without a page component', function () {
+    hybridly()->setRootView(Hybridly::DEFAULT_ROOT_VIEW);
+    hybridly()->setVersion('123');
+
+    $request = mockRequest(url: '/users/makise', hybridly: true, bind: true);
+    $factory = hybridly(properties: ['user' => 'Makise Kurisu']);
+    $response = $factory->toResponse($request);
+    $payload = $response->getOriginalContent();
+
+    expect($factory)->toBeInstanceOf(Factory::class);
+    expect($response)->toBeInstanceOf(JsonResponse::class);
+    expect($payload)->toMatchArray([
+        'dialog' => null,
+        'version' => '123',
+        'url' => 'http://localhost/users/makise',
+        'view' => [
+            'component' => null,
+            'properties' => [
+                'user' => 'Makise Kurisu',
+            ],
+        ],
+    ]);
+});
+
+test('hybridly responses without a page component on initial load', function () {
+    hybridly()->setRootView(Hybridly::DEFAULT_ROOT_VIEW);
+    hybridly()->setVersion('123');
+
+    $request = mockRequest(url: '/users/makise', hybridly: false, bind: true);
+    $factory = hybridly(properties: ['user' => 'Makise Kurisu']);
+    $factory->toResponse($request);
+})->throws(MissingViewComponentException::class);


### PR DESCRIPTION
This pull request allows responses that only return properties, without specifying a page component:

```php
public function store(UpdateUserRequest $request): HybridResponse
{
    $user = User::update($request->validate());

    return \Hybridly\view(properties: [
        'user' => $user,
    ]);
}
```

In this situation, Hybridly will **merge** the received properties with the existing ones, and preserve the current URL.

This is useful in situations where you want to avoid a `redirect()->back()` that would require another server round-trip and computing the properties of the associated `GET` controller.

Note that attempting to return a hybrid response with a page component on initial page loads will result in an exception being thrown, as the front-end would have nothing to display.