### PR TITLE
feat: deferred properties

### DIFF
--- a/docs/api/laravel/functions.md
+++ b/docs/api/laravel/functions.md
@@ -20,6 +20,76 @@ Otherwise, it is an alias of [`hybridly()->view()`](./hybridly.md#view).
 
 The functions live in the `\Hybridly` namespace and need to be imported before being used.
 
+### `view`
+
+Renders a view with the given component and optional properties. The properties can be an array, an `Arrayable` or a [data object](http://localhost:5173/guide/typescript.html#data-objects).
+
+> See also: [responses](../../guide/responses.md)
+
+```php
+use function Hybridly\view;
+
+return view('user.show', $user);
+```
+
+### `properties`
+
+Returns updated properties for an existing view.
+
+> See also: [properties-only responses](../../guide/responses.md#updating-properties)
+
+```php
+use function Hybridly\properties;
+
+return properties([
+	'user' => $user,
+]);
+```
+
+### `partial`
+
+Creates a [partial-only](../../guide/partial-reloads.md#partial-only-properties) property.
+
+> See also: [partial properties](../../guide/partial-reloads.md#partial-only-properties)
+
+```php
+use function Hybridly\view;
+use function Hybridly\partial;
+
+return view('user.show', [
+    'user' => $user,
+    'posts' => partial(fn () => Post::forUser($user)->paginate()),
+]);
+```
+
+### `deferred`
+
+Creates a partial property that will automatically be loaded in a subsequent partial reload when the page loads.
+
+> See also: [deferred properties](../../guide/partial-reloads.md#deferred-properties)
+
+```php
+use function Hybridly\view;
+use function Hybridly\deferred;
+
+return view('user.show', [
+    'user' => $user,
+    'posts' => deferred(fn () => Post::forUser($user)->paginate()),
+]);
+```
+
+### `to_external_url`
+
+Redirects to a non-hybrid page or an external domain.
+
+> See also: [external redirects](../../guide/responses.md#external-redirects).
+
+```php
+use function Hybridly\to_external_url;
+
+return to_external_url('https://google.com');
+```
+
 ### `is_hybrid`
 
 Determines whether the current request is hybrid. Optionally, a `Illuminate\Http\Request` instance can be given instead of using the current request.
@@ -42,52 +112,6 @@ use function Hybridly\is_partial;
 if (is_partial()) {
   // ...
 }
-```
-
-### `view`
-
-Renders a hybrid view. This is the same as calling [`hybridly()->view()`](./hybridly.md#view).
-
-```php
-use function Hybridly\view;
-
-return view('user.show', $user);
-```
-
-### `properties`
-
-Returns updated properties for an existing view. This is the same as calling [`hybridly()->properties()`](./hybridly.md#properties).
-
-```php
-use function Hybridly\properties;
-
-return properties([
-	'user' => $user,
-]);
-```
-
-### `partial`
-
-Creates a [partial-only](../../guide/partial-reloads.md#partial-only-properties) property. This is the same as calling [`hybridly()->partial()`](./hybridly.md#partial).
-
-```php
-use function Hybridly\view;
-use function Hybridly\partial;
-
-return view('user.show', [
-    'user' => $user,
-    'posts' => partial(fn () => Post::forUser($user)->paginate()),
-]);
-```
-
-### `to_external_url`
-
-Redirects to a non-hybrid page or an external domain. This is the same as calling [`hybridly()->external()`](./hybridly.md#external).
-
-```php
-use function Hybridly\to_external_url;
-
-return to_external_url('https://google.com');
 ```
 
 ## Namespaced testing functions

--- a/docs/api/laravel/functions.md
+++ b/docs/api/laravel/functions.md
@@ -22,7 +22,7 @@ The functions live in the `\Hybridly` namespace and need to be imported before b
 
 ### `view`
 
-Renders a view with the given component and optional properties. The properties can be an array, an `Arrayable` or a [data object](http://localhost:5173/guide/typescript.html#data-objects).
+Renders a view with the given component and optional properties. The properties can be an array, an `Arrayable` or a [data object](../../guide/typescript#data-objects).
 
 > See also: [responses](../../guide/responses.md)
 

--- a/docs/api/laravel/hybridly.md
+++ b/docs/api/laravel/hybridly.md
@@ -1,6 +1,8 @@
 # Hybridly
 
-`Hybridly\Hybridly` is a singleton instance that contains shortcuts for common actions. It can be accessed by dependency injection or by service location using the [`hybridly()` global function](./functions.md#hybridly).
+`Hybridly\Hybridly` is a singleton instance that contains convenience methods for common actions. It can be accessed by dependency injection or by service location using the [`hybridly()` global function](./functions.md#hybridly).
+
+Note that most of the methods here have an equivalent [namespaced function](./functions.md#namespaced-functions).
 
 ## `view`
 
@@ -76,6 +78,25 @@ Creates a property that will only get evaluated and included when specifically r
 return hybridly('booking.estimates.show', [
   'booking' => BookingData::from($booking)
   'estimates' => hybridly()->partial(function () { // [!code focus:3]
+    return SearchEstimates::run($booking);
+  }),
+]);
+```
+
+## `deferred`
+
+Creates a partial property that will automatically be loaded in a subsequent partial reload when the page loads.
+
+> See also: [`deferred`](./functions.md#deferred), [`partial`](./functions.md#partial)
+> 
+> See [deferred properties](../../guide/partial-reloads.md#deferred-properties) for more details.
+
+### Usage
+
+```php
+return hybridly('booking.estimates.show', [
+  'booking' => BookingData::from($booking)
+  'estimates' => hybridly()->deferred(function () { // [!code focus:3]
     return SearchEstimates::run($booking);
   }),
 ]);

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -181,6 +181,8 @@ export interface View {
 	component?: string
 	/** Properties to apply to the component. */
 	properties: Properties
+	/** Deferred properties for this view. */
+	deferred: string[]
 }
 
 export interface Dialog extends Required<View> {

--- a/packages/laravel/src/Hybridly.php
+++ b/packages/laravel/src/Hybridly.php
@@ -2,6 +2,7 @@
 
 namespace Hybridly;
 
+use Hybridly\Support\Deferred;
 use Hybridly\Support\Header;
 use Hybridly\Support\Partial;
 use Hybridly\Support\VueViewFinder;
@@ -83,6 +84,17 @@ final class Hybridly
     public function partial(\Closure $callback): Partial
     {
         return new Partial($callback);
+    }
+
+    /**
+     * Creates a deferred property that will not be included in an initial loaded,
+     * but will automatically be loaded in a subsequent partial reload.
+     *
+     * @see https://hybridly.dev/api/laravel/hybridly.html#deferred
+     */
+    public function deferred(\Closure $callback): Deferred
+    {
+        return new Deferred($callback);
     }
 
     /**

--- a/packages/laravel/src/Support/Deferred.php
+++ b/packages/laravel/src/Support/Deferred.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hybridly\Support;
+
+/**
+ * Represents a property that will automatically get evaluated in a subsequent partial reload after the page has loaded.
+ */
+class Deferred extends Partial
+{
+}

--- a/packages/laravel/src/Support/Partial.php
+++ b/packages/laravel/src/Support/Partial.php
@@ -5,7 +5,7 @@ namespace Hybridly\Support;
 /**
  * Represents a property that will get evaluated only when specified in a partial reload.
  */
-final class Partial
+class Partial
 {
     public function __construct(
         private readonly \Closure $callback,

--- a/packages/laravel/src/Support/PropertiesResolver.php
+++ b/packages/laravel/src/Support/PropertiesResolver.php
@@ -21,14 +21,17 @@ final class PropertiesResolver
             ? $this->request->headers->has(Header::PARTIAL_COMPONENT)
             : $this->request->header(Header::PARTIAL_COMPONENT) === $component;
 
+        $deferred = [];
+
         if (!$partial) {
+            $deferred = $this->resolveDeferredProperties($this->resolveArrayableProperties($properties));
             $properties = Arr::filterRecursive($properties, static fn ($property) => !($property instanceof Partial));
         }
 
         // First, we need to resolve property instances to an array that
         // we can recursively traverse. This is needed to include
         // or exclude properties using the dot-notation.
-        $properties = $this->resolvePropertyInstances($properties);
+        $properties = $this->resolveArrayableProperties($properties);
 
         // The `only` and `except` headers contain json-encoded array data. We want to use them to
         // retrieve the properties whose paths they describe using dot-notation.
@@ -45,18 +48,44 @@ final class PropertiesResolver
             $properties = Arr::exceptDot($properties, $except);
         }
 
-        return $this->convertOutputCase(
+        $properties = $this->convertOutputCase(
             // Only when we only have the properties we need, we can
             // evaluated the lazy ones. If we did it earlier, we
             // could evaluate them even if they were excluded.
             array: $this->evaluatePropertyInstances($properties),
         );
+
+        return [$properties, $deferred];
+    }
+
+    /**
+     * Resolves which properties are deferred.
+     */
+    protected function resolveDeferredProperties(array $properties, string $path = ''): array
+    {
+        $deferred = [];
+
+        foreach ($properties as $key => $value) {
+            if ($value instanceof Arrayable) {
+                $value = $value->toArray();
+            }
+
+            if (\is_array($value)) {
+                $deferred = array_merge($deferred, $this->resolveDeferredProperties($value, $path ? ("{$path}.{$key}") : $key));
+            }
+
+            if ($value instanceof Deferred) {
+                $deferred[] = ($path ? ("{$path}.{$key}") : $key);
+            }
+        }
+
+        return $deferred;
     }
 
     /**
      * Resolves all specific property instances to an array.
      */
-    protected function resolvePropertyInstances(array $properties, bool $unpackDotProps = true): array
+    protected function resolveArrayableProperties(array $properties, bool $unpackDotProps = true): array
     {
         foreach ($properties as $key => $value) {
             if ($value instanceof Arrayable) {
@@ -64,7 +93,7 @@ final class PropertiesResolver
             }
 
             if (\is_array($value)) {
-                $value = $this->resolvePropertyInstances($value, unpackDotProps: false);
+                $value = $this->resolveArrayableProperties($value, unpackDotProps: false);
             }
 
             if ($unpackDotProps && str_contains($key, '.')) {

--- a/packages/laravel/src/Support/helpers.php
+++ b/packages/laravel/src/Support/helpers.php
@@ -2,6 +2,7 @@
 
 namespace Hybridly;
 
+use Hybridly\Support\Deferred;
 use Hybridly\Support\Partial;
 use Hybridly\View\Factory;
 use Illuminate\Contracts\Support\Arrayable;
@@ -67,6 +68,18 @@ if (!\function_exists('Hybridly\partial')) {
     function partial(\Closure $closure): Partial
     {
         return hybridly()->partial($closure);
+    }
+}
+
+if (!\function_exists('Hybridly\deferred')) {
+    /**
+     * Creates a deferred property that will automatically be loaded in a subsequent partial reload.
+     *
+     * @see https://hybridly.dev/api/laravel/functions.html#deferred
+     */
+    function deferred(\Closure $closure): Deferred
+    {
+        return hybridly()->deferred($closure);
     }
 }
 

--- a/packages/laravel/src/View/Factory.php
+++ b/packages/laravel/src/View/Factory.php
@@ -166,13 +166,15 @@ class Factory implements HybridResponse
 
     protected function renderDialog(Request $request, Payload $payload)
     {
+        [$properties] = $this->resolveProperties($payload->dialog, $request);
+
         return new Payload(
             view: $this->getBaseView($payload->dialog->redirectUrl, $request),
             url: $payload->url,
             version: $payload->version,
             dialog: new Dialog(
                 component: $payload->dialog->component,
-                properties: $this->resolveProperties($payload->dialog, $request),
+                properties: $properties,
                 baseUrl: $payload->dialog->baseUrl,
                 redirectUrl: $payload->dialog->redirectUrl,
                 key: $payload->dialog->key,
@@ -241,6 +243,7 @@ class Factory implements HybridResponse
             view: new View(
                 component: $this->view->component,
                 properties: Arr::except($this->view->properties, array_keys($this->hybridly->shared())),
+                deferred: [],
             ),
         );
     }
@@ -250,9 +253,12 @@ class Factory implements HybridResponse
      */
     protected function resolveView(View $view, Request $request): View
     {
+        [$properties, $deferred] = $this->resolveProperties($view, $request);
+
         return new View(
             component: $view->component,
-            properties: $this->resolveProperties($view, $request),
+            properties: $properties,
+            deferred: $deferred,
         );
     }
 

--- a/packages/laravel/src/View/View.php
+++ b/packages/laravel/src/View/View.php
@@ -9,6 +9,7 @@ class View implements Arrayable
     public function __construct(
         public ?string $component,
         public array $properties,
+        public array $deferred = [],
     ) {
     }
 
@@ -17,6 +18,7 @@ class View implements Arrayable
         return [
             'component' => $this->component,
             'properties' => $this->properties,
+            'deferred' => $this->deferred,
         ];
     }
 }

--- a/packages/vue/src/devtools.ts
+++ b/packages/vue/src/devtools.ts
@@ -42,6 +42,12 @@ export function setupDevtools(app: App) {
 
 			payload.instanceData.state.push({
 				type: hybridlyStateType,
+				key: 'deferred',
+				value: state.context.value?.view.deferred,
+			})
+
+			payload.instanceData.state.push({
+				type: hybridlyStateType,
 				key: 'dialog',
 				value: state.context.value?.dialog,
 			})

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,7 +14,7 @@ uses(TestCase::class)
     ->beforeEach(fn () => config()->set('hybridly.testing.ensure_pages_exist', false))
     ->in(__DIR__);
 
-function mockRequest(string $url = '/', string $method = 'GET', bool $bind = false, bool $hybridly = true, array $headers = []): Request
+function mock_request(string $url = '/', string $method = 'GET', bool $bind = false, bool $hybridly = true, array $headers = []): Request
 {
     $request = Request::create($url, $method);
 
@@ -33,7 +33,7 @@ function mockRequest(string $url = '/', string $method = 'GET', bool $bind = fal
     return $request;
 }
 
-function makeMockRequest(mixed $response, string $url = '/mock-url'): TestResponse
+function make_mock_request(mixed $response, string $url = '/mock-url'): TestResponse
 {
     app('router')->get($url, function () use ($response) {
         return $response;
@@ -42,9 +42,9 @@ function makeMockRequest(mixed $response, string $url = '/mock-url'): TestRespon
     return get($url);
 }
 
-function makeHybridMockRequest(string $component = 'test', mixed $properties = [], string $url = '/hybrid-mock-url'): TestResponse
+function make_hybrid_mock_request(string $component = 'test', mixed $properties = [], string $url = '/hybrid-mock-url'): TestResponse
 {
-    return makeMockRequest(
+    return make_mock_request(
         response: hybridly($component, $properties),
         url: $url,
     );

--- a/tests/src/Laravel/DirectivesTest.php
+++ b/tests/src/Laravel/DirectivesTest.php
@@ -45,6 +45,6 @@ it('renders encoded payload in the data-payload attribute', function () {
     $html = Blade::render($php, ['payload' => $payload], true);
 
     expect($html)->toBe(trim(<<<HTML
-        <div id="root" class="" data-payload="{&quot;view&quot;:{&quot;component&quot;:&quot;users.edit&quot;,&quot;properties&quot;:{&quot;user&quot;:&quot;Makise Kurisu&quot;}},&quot;url&quot;:&quot;https:\/\/localhost\/&quot;,&quot;version&quot;:&quot;abc123&quot;,&quot;dialog&quot;:null}"></div>
+        <div id="root" class="" data-payload="{&quot;view&quot;:{&quot;component&quot;:&quot;users.edit&quot;,&quot;properties&quot;:{&quot;user&quot;:&quot;Makise Kurisu&quot;},&quot;deferred&quot;:[]},&quot;url&quot;:&quot;https:\/\/localhost\/&quot;,&quot;version&quot;:&quot;abc123&quot;,&quot;dialog&quot;:null}"></div>
     HTML));
 });

--- a/tests/src/Laravel/Support/DataTest.php
+++ b/tests/src/Laravel/Support/DataTest.php
@@ -22,7 +22,7 @@ function resolve_properties(array $properties, array $headers = [], array $persi
         'request' => $request,
     ]);
 
-    return $resolver->resolve($component, $properties, $persisted);
+    return $resolver->resolve($component, $properties, $persisted)[0];
 }
 
 test('partial properties in data objects are ignored like normal partial properties', function () {

--- a/tests/src/Laravel/Testing/AssertableTest.php
+++ b/tests/src/Laravel/Testing/AssertableTest.php
@@ -3,13 +3,13 @@
 use Hybridly\Testing\Assertable;
 
 test('the `view` method asserts that the view is the expected value', function () {
-    makeHybridMockRequest()->assertHybrid(function (Assertable $page) {
+    make_hybrid_mock_request()->assertHybrid(function (Assertable $page) {
         $page->view('test');
     });
 });
 
 test('the `url` method asserts that the url is the expected value', function () {
-    makeHybridMockRequest(url: '/url-to-a-hybrid-page')->assertHybrid(function (Assertable $page) {
+    make_hybrid_mock_request(url: '/url-to-a-hybrid-page')->assertHybrid(function (Assertable $page) {
         $page->url(config('app.url') . '/url-to-a-hybrid-page');
     });
 });
@@ -17,13 +17,13 @@ test('the `url` method asserts that the url is the expected value', function () 
 test('the `version` method asserts that the version is the expected value', function () {
     hybridly()->setVersion('owo');
 
-    makeHybridMockRequest()->assertHybrid(function (Assertable $page) {
+    make_hybrid_mock_request()->assertHybrid(function (Assertable $page) {
         $page->version('owo');
     });
 });
 
 test('the `getPayload` method returns the payload', function () {
-    makeHybridMockRequest()->assertHybrid(function (Assertable $page) {
+    make_hybrid_mock_request()->assertHybrid(function (Assertable $page) {
         expect($page->getPayload())->toBeArray();
         expect($page->getPayload())->toHaveKeys([
             'view',
@@ -37,7 +37,7 @@ test('the `getPayload` method returns the payload', function () {
 });
 
 test('the `getValue` method returns the value at the given path', function () {
-    makeHybridMockRequest(properties: ['foo' => 'bar'])
+    make_hybrid_mock_request(properties: ['foo' => 'bar'])
         ->assertHybrid(function (Assertable $page) {
             expect($page->getValue('view.component'))->toBe('test');
             expect($page->getValue('view.properties.foo'))->toBe('bar');
@@ -45,14 +45,14 @@ test('the `getValue` method returns the value at the given path', function () {
 });
 
 test('the `getProperty` method returns the property value at the given path', function () {
-    makeHybridMockRequest(properties: ['foo' => 'bar'])
+    make_hybrid_mock_request(properties: ['foo' => 'bar'])
         ->assertHybrid(function (Assertable $page) {
             expect($page->getProperty('foo'))->toBe('bar');
         });
 });
 
 test('the `toArray` function converts the Assertable instance to an array', function () {
-    makeHybridMockRequest()->assertHybrid(function (Assertable $page) {
+    make_hybrid_mock_request()->assertHybrid(function (Assertable $page) {
         expect($page->toArray())->toBeArray();
         expect($page->getPayload())->toHaveKeys([
             'view',

--- a/tests/src/Laravel/Testing/TestResponseMacrosTest.php
+++ b/tests/src/Laravel/Testing/TestResponseMacrosTest.php
@@ -9,7 +9,7 @@ use function Pest\Laravel\get;
 test('the `assertHybrid` method runs its callback', function () {
     $success = false;
 
-    makeHybridMockRequest()->assertHybrid(function (Assertable $page) use (&$success) {
+    make_hybrid_mock_request()->assertHybrid(function (Assertable $page) use (&$success) {
         expect($page)->toBeInstanceOf(Assertable::class);
         $success = true;
     });
@@ -34,11 +34,11 @@ test('the `assertHybridDialog` method asserts dialog view component & base url &
 });
 
 test('the `assertNotHybrid` method asserts that non-hybrid responses are non-hybrid', function () {
-    makeMockRequest(response: 'hello-world')->assertNotHybrid();
+    make_mock_request(response: 'hello-world')->assertNotHybrid();
     $success = false;
 
     try {
-        makeHybridMockRequest()->assertNotHybrid();
+        make_hybrid_mock_request()->assertNotHybrid();
     } catch (\PHPUnit\Framework\AssertionFailedError) {
         $success = true;
     }
@@ -47,7 +47,7 @@ test('the `assertNotHybrid` method asserts that non-hybrid responses are non-hyb
 });
 
 test('the `assertHasHybridProperty` method asserts the given property exists', function () {
-    $response = makeHybridMockRequest(properties: [
+    $response = make_hybrid_mock_request(properties: [
         'foo' => 'bar',
         'nested' => [
             'foo' => 'bar',
@@ -59,17 +59,17 @@ test('the `assertHasHybridProperty` method asserts the given property exists', f
 });
 
 test('the `assertMissingHybridProperty` method asserts the given property is missing', function () {
-    makeHybridMockRequest(properties: ['foo' => 'bar'])
+    make_hybrid_mock_request(properties: ['foo' => 'bar'])
         ->assertMissingHybridProperty('owo');
 });
 
 test('the `assertHybridProperty` method asserts the property at the given path has the expected value', function () {
-    makeHybridMockRequest(properties: ['foo' => 'bar'])
+    make_hybrid_mock_request(properties: ['foo' => 'bar'])
         ->assertHybridProperty('foo', 'bar');
 });
 
 test('the `assertHybridProperties` method asserts the properties using the given array', function () {
-    makeHybridMockRequest(properties: [
+    make_hybrid_mock_request(properties: [
         'case1' => 'abc',
         'case2' => 'bar',
         'case3' => 'zyx',
@@ -109,33 +109,33 @@ test('the `assertHybridProperties` method asserts the properties using the given
 });
 
 test('the `assertHybridPayload` method asserts the payload property at the given path has the expected value', function () {
-    makeHybridMockRequest(properties: ['foo' => 'bar'])
+    make_hybrid_mock_request(properties: ['foo' => 'bar'])
         ->assertHybridPayload('view.component', 'test')
         ->assertHybridPayload('view.properties', ['foo' => 'bar']);
 });
 
 test('the `assertHybridView` method asserts the hybrid response view is the expected value', function () {
-    makeHybridMockRequest(component: 'some.dotted.view')
+    make_hybrid_mock_request(component: 'some.dotted.view')
         ->assertHybridView('some.dotted.view');
 });
 
 test('the `assertHybridVersion` method asserts the hybrid response version is the expected value', function () {
     hybridly()->setVersion('owo');
-    makeHybridMockRequest()->assertHybridVersion('owo');
+    make_hybrid_mock_request()->assertHybridVersion('owo');
 });
 
 test('the `assertHybridUrl` method asserts the hybrid response url is the expected value', function () {
-    makeHybridMockRequest()
+    make_hybrid_mock_request()
         ->assertHybridUrl(config('app.url') . '/hybrid-mock-url');
 });
 
 test('the `assertHybrid` method returns a `TestResponse` instance', function () {
-    expect(makeHybridMockRequest()->assertHybrid())
+    expect(make_hybrid_mock_request()->assertHybrid())
         ->toBeInstanceOf(TestResponse::class);
 });
 
 test('the `getHybridPayload` method returns the payload of the hybrid response', function () {
-    $response = makeHybridMockRequest(properties: ['bar' => 'baz']);
+    $response = make_hybrid_mock_request(properties: ['bar' => 'baz']);
 
     tap($response->getHybridPayload(), function (array $page) {
         expect($page['view']['component'])->toBe('test');
@@ -147,7 +147,7 @@ test('the `getHybridPayload` method returns the payload of the hybrid response',
 });
 
 test('the `getHybridProperty` method returns the given property', function () {
-    $response = makeHybridMockRequest(properties: [
+    $response = make_hybrid_mock_request(properties: [
         'foo' => 'bar',
         'uwu' => [
             'owo' => 'hewwo',

--- a/tests/src/Laravel/View/FactoryTest.php
+++ b/tests/src/Laravel/View/FactoryTest.php
@@ -65,6 +65,7 @@ test('hybridly responses to non-hybridly requests', function () {
             'properties' => [
                 'user' => 'Makise Kurisu',
             ],
+            'deferred' => [],
         ],
     ]);
 });
@@ -89,6 +90,7 @@ test('hybridly responses to hybridly requests', function () {
             'properties' => [
                 'user' => 'Makise Kurisu',
             ],
+            'deferred' => [],
         ],
     ]);
 });
@@ -116,6 +118,7 @@ test('properties can be added on-the-fly on the factory instance', function () {
                 'user' => 'Makise Kurisu',
                 'husband' => 'Okabe Rintarou',
             ],
+            'deferred' => [],
         ],
     ]);
 });
@@ -140,6 +143,7 @@ test('dialogs and their properties can be resolved', function () {
             'properties' => [
                 'foo' => 'bar',
             ],
+            'deferred' => [],
         ],
         'dialog' => [
             'component' => 'users.edit',
@@ -189,6 +193,7 @@ test('hybridly responses without a page component', function () {
             'properties' => [
                 'user' => 'Makise Kurisu',
             ],
+            'deferred' => [],
         ],
     ]);
 });

--- a/tests/src/Laravel/View/FactoryTest.php
+++ b/tests/src/Laravel/View/FactoryTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 test('external responses to non-hybridly requests', function () {
-    mockRequest(hybridly: false, bind: true);
+    mock_request(hybridly: false, bind: true);
 
     expect(hybridly()->external('https://google.fr/'))
         ->toBeInstanceOf(RedirectResponse::class)
@@ -22,7 +22,7 @@ test('external responses to non-hybridly requests', function () {
 });
 
 test('external responses to hybridly requests', function () {
-    mockRequest(hybridly: true, bind: true);
+    mock_request(hybridly: true, bind: true);
 
     expect(hybridly()->external('https://google.fr/'))
         ->toBeInstanceOf(Response::class)
@@ -33,7 +33,7 @@ test('external responses to hybridly requests', function () {
 });
 
 test('external responses with redirect responses as input', function () {
-    mockRequest(hybridly: true, bind: true);
+    mock_request(hybridly: true, bind: true);
 
     $redirect = new RedirectResponse('https://google.fr/');
 
@@ -49,7 +49,7 @@ test('hybridly responses to non-hybridly requests', function () {
     hybridly()->setRootView(Hybridly::DEFAULT_ROOT_VIEW);
     hybridly()->setVersion('123');
 
-    $request = mockRequest(url: '/users/makise', hybridly: false, bind: true);
+    $request = mock_request(url: '/users/makise', hybridly: false, bind: true);
     $factory = hybridly('users.edit', ['user' => 'Makise Kurisu']);
     $response = $factory->toResponse($request);
     $payload = $response->getOriginalContent()->getData()['payload'];
@@ -74,7 +74,7 @@ test('hybridly responses to hybridly requests', function () {
     hybridly()->setRootView(Hybridly::DEFAULT_ROOT_VIEW);
     hybridly()->setVersion('123');
 
-    $request = mockRequest(url: '/users/makise', hybridly: true, bind: true);
+    $request = mock_request(url: '/users/makise', hybridly: true, bind: true);
     $factory = hybridly('users.edit', ['user' => 'Makise Kurisu']);
     $response = $factory->toResponse($request);
     $payload = $response->getOriginalContent();
@@ -99,7 +99,7 @@ test('properties can be added on-the-fly on the factory instance', function () {
     hybridly()->setRootView(Hybridly::DEFAULT_ROOT_VIEW);
     hybridly()->setVersion('123');
 
-    $request = mockRequest(url: '/users/makise', hybridly: true, bind: true);
+    $request = mock_request(url: '/users/makise', hybridly: true, bind: true);
     $factory = hybridly('users.edit', ['user' => 'Makise Kurisu'])
         ->with('husband', 'Okabe Rintarou');
 
@@ -126,7 +126,7 @@ test('properties can be added on-the-fly on the factory instance', function () {
 test('dialogs and their properties can be resolved', function () {
     Route::get('/', fn () => hybridly('index', ['foo' => 'bar']))->name('index');
 
-    $request = mockRequest(url: '/users/makise', hybridly: true, bind: true);
+    $request = mock_request(url: '/users/makise', hybridly: true, bind: true);
     $factory = hybridly('users.edit', [
         'user' => 'Makise Kurisu',
         'email' => fn () => 'makise@gadgetlab.jp',
@@ -163,7 +163,7 @@ test('dialogs and their properties can be resolved', function () {
 test('the url resolver is used when constructing a response', function () {
     hybridly()->setUrlResolver(fn (Request $request) => 'https://customdomain.com' . $request->getRequestUri());
 
-    $request = mockRequest(url: '/users/makise', hybridly: true, bind: true);
+    $request = mock_request(url: '/users/makise', hybridly: true, bind: true);
     $payload = hybridly('foo.bar')
         ->toResponse($request)
         ->getOriginalContent();
@@ -177,7 +177,7 @@ test('hybridly responses without a page component', function () {
     hybridly()->setRootView(Hybridly::DEFAULT_ROOT_VIEW);
     hybridly()->setVersion('123');
 
-    $request = mockRequest(url: '/users/makise', hybridly: true, bind: true);
+    $request = mock_request(url: '/users/makise', hybridly: true, bind: true);
     $factory = hybridly(properties: ['user' => 'Makise Kurisu']);
     $response = $factory->toResponse($request);
     $payload = $response->getOriginalContent();
@@ -202,7 +202,7 @@ test('hybridly responses without a page component on initial load', function () 
     hybridly()->setRootView(Hybridly::DEFAULT_ROOT_VIEW);
     hybridly()->setVersion('123');
 
-    $request = mockRequest(url: '/users/makise', hybridly: false, bind: true);
+    $request = mock_request(url: '/users/makise', hybridly: false, bind: true);
     $factory = hybridly(properties: ['user' => 'Makise Kurisu']);
     $factory->toResponse($request);
 })->throws(MissingViewComponentException::class);


### PR DESCRIPTION
This pull request introduces deferred properties, inspired by https://github.com/inertiajs/inertia-laravel/pull/531 from @adrum.

Deferred properties are like partial properties, except they _automatically load_ after the page component is mounted. This is quite useful to improve the performance on pages where certain properties take time to load.

```php
use function Hybridly\deferred;

return hybridly('foo', [
	'slowProperty' => deferred(fn () => $fetchDataFromThirdParty())
]);
```

Note that this pattern can already be used by manually making a partial reload in the `onMounted` hook:

```ts
defineProps<{
	slowProperty?: Data.ThirdPartyDataType
}>()

onMounted(() => {
	router.reload({ only: ['slowProperty'] })
})
```