### PR TITLE
refactor: make `view` and `page` usage consistent

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -92,7 +92,7 @@ export default defineConfig({
 					text: 'Essentials',
 					collapsed: false,
 					items: [
-						{ text: 'Pages & layouts', link: '/guide/pages-and-layouts' },
+						{ text: 'Views & layouts', link: '/guide/views-and-layouts' },
 						{ text: 'Routing', link: '/guide/routing' },
 						{ text: 'Responses', link: '/guide/responses' },
 						{ text: 'Navigation', link: '/guide/navigation' },

--- a/docs/.vitepress/theme/components/marketing.vue
+++ b/docs/.vitepress/theme/components/marketing.vue
@@ -52,7 +52,7 @@ const features: Feature[] = [
 	{
 		icon: 'i-mdi:microsoft-visual-studio-code',
 		title: 'Visual Studio Code',
-		description: 'Auto-complete component names, and navigate between controllers, layouts and pages with a single click.',
+		description: 'Auto-complete component names, and navigate between controllers, layouts and views with a single click.',
 		url: '/guide/visual-studio-code',
 	},
 	{

--- a/docs/api/components/router-link.md
+++ b/docs/api/components/router-link.md
@@ -1,6 +1,6 @@
 # `<router-link>`
 
-This built-in component can be used to replace [anchor tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) to navigate from a hybrid page to another.
+This built-in component can be used to replace [anchor tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) to navigate from a hybrid view to another.
 
 This component is a wrapper around Vue's [`<Component>` ](https://vuejs.org/api/built-in-special-elements.html#component). By default, it creates anchors elements but intercepts their click handlers to make [hybrid navigations](../../guide/navigation.md).
 
@@ -9,7 +9,7 @@ This component is a wrapper around Vue's [`<Component>` ](https://vuejs.org/api/
 - **Required**: true
 - **Type**: `string`
 
-Similar to the `<a>` tag, accepts the hyperlink to navigate to. If this doesn't point to a hybrid page, set the [`external`](#external) property to `true`.
+Similar to the `<a>` tag, accepts the hyperlink to navigate to. If this doesn't point to a hybrid view, set the [`external`](#external) property to `true`.
 
 ### Usage
 

--- a/docs/api/laravel/functions.md
+++ b/docs/api/laravel/functions.md
@@ -86,7 +86,7 @@ return view('user.show', [
 
 ### `to_external_url`
 
-Redirects to a non-hybrid page or an external domain.
+Redirects to a non-hybrid view or an external domain.
 
 > See also: [external redirects](../../guide/responses.md#external-redirects).
 
@@ -134,7 +134,7 @@ Otherwise, it is an alias of [`hybridly()->view()`](./hybridly.md#view).
 
 ### `partial_headers`
 
-Generates headers for testing partial requests. The first parameter is the page component name, and the second and third parameters are an array of `only` and `except` properties, respectively.
+Generates headers for testing partial requests. The first parameter is the view component name, and the second and third parameters are an array of `only` and `except` properties, respectively.
 
 > See also: [partial reloads](../../guide/partial-reloads.md)
 

--- a/docs/api/laravel/hybridly.md
+++ b/docs/api/laravel/hybridly.md
@@ -34,7 +34,7 @@ return hybridly()->properties([
 
 ## `base`
 
-Makes the view a [dialog](../../guide/dialogs.md) and defines its base page. It takes a route name and its parameters as its arguments.
+Makes the view a [dialog](../../guide/dialogs.md) and defines its base view. It takes a route name and its parameters as its arguments.
 
 > See [dialogs](../../guide/dialogs.md) for more details.
 
@@ -50,9 +50,9 @@ return hybridly()
 
 ## `external`
   
-Generates a response for redirecting to an external website, or a non-hybrid page. 
+Generates a response for redirecting to an external website, or a non-hybrid view. 
 
-This can also be used to redirect to a hybrid page when it is not known whether the current request is hybrid or not.
+This can also be used to redirect to a hybrid view when it is not known whether the current request is hybrid or not.
 
 > See also: [`to_external_url`](./functions.md#to-external-url)
 > 
@@ -134,7 +134,7 @@ if (hybridly()->isPartial()) {
 
 > See also: [architecture](../../guide/architecture.md#custom)
 
-Loads pages, layouts and components from the given directory. They must be located in the `pages`, `layouts` and `components` directories, respectively.
+Loads views, layouts and components from the given directory. They must be located in the `views`, `layouts` and `components` directories, respectively.
 
 ### Usage
 
@@ -152,7 +152,7 @@ public function boot(Hybridly $hybridly): void
 
 > See also: [architecture](../../guide/architecture.md#custom)
 
-Loads pages, layouts and components from the subdirectories of the given directory.
+Loads views, layouts and components from the subdirectories of the given directory.
 
 ### Usage
 
@@ -175,7 +175,7 @@ Recursively loads Vue files in the given directory and registers them as views f
 public function boot(Hybridly $hybridly): void
 {
     $hybridly->loadViewsFrom(
-      directory: __DIR__.'/pages',
+      directory: __DIR__.'/views',
       namespace: 'billing',
     );
 }

--- a/docs/api/laravel/testing.md
+++ b/docs/api/laravel/testing.md
@@ -38,9 +38,9 @@ This method asserts that the given hybrid property is missing in the response. I
 
 ### `assertHybridView`
 
-This method asserts that the page component of the hybrid response is equal to the given value. Additionally, if `hybridly.testing.ensure_pages_exist` is set to `true`, which it is by default, it will ensure that the page component exists.
+This method asserts that the view component of the hybrid response is equal to the given value. Additionally, if `hybridly.testing.ensure_views_exist` is set to `true`, which it is by default, it will ensure that the view component exists.
 
-To ensure the page component's existence, the paths defined in `hybridly.testing.page_paths` will be used.
+To ensure the view component's existence, the paths defined in `hybridly.testing.view_paths` will be used.
 
 ### `assertHybridVersion`
 

--- a/docs/api/router/utils.md
+++ b/docs/api/router/utils.md
@@ -97,7 +97,7 @@ router.matches('profile', { user: currentUserId })
 
 ## `dialog.close`
 
-This function closes the current dialog. It takes the same options as the other router functions, as well as a `local` option that indicates whether a round-trip to the server will be made to update the base page's properties.
+This function closes the current dialog. It takes the same options as the other router functions, as well as a `local` option that indicates whether a round-trip to the server will be made to update the base view's properties.
 
 ```ts
 router.dialog.close()

--- a/docs/api/utils/define-layout-properties.md
+++ b/docs/api/utils/define-layout-properties.md
@@ -1,6 +1,6 @@
 # `defineLayoutProperties`
 
-This function can be used to define the [properties](../../guide/pages-and-layouts.md#persistent-layout-properties) of the currently-defined persistent layout.
+This function can be used to define the [properties](../../guide/views-and-layouts.md#persistent-layout-properties) of the currently-defined persistent layout.
 
 | Related                                           | [`defineLayout`](./define-layout.md)                  |
 | ------------------------------------------------- | ----------------------------------------------------- |
@@ -11,7 +11,7 @@ This function can be used to define the [properties](../../guide/pages-and-layou
 `defineLayoutProperties` accepts a single argument, an object that contains the layout properties. This function cannot be typed automatically.
 
 :::code-group
-```vue [pages/index.vue]
+```vue [views/index.vue]
 <script setup lang="ts">
 defineLayoutProperties({ // [!code focus:3]
   fluid: true

--- a/docs/api/utils/define-layout.md
+++ b/docs/api/utils/define-layout.md
@@ -1,6 +1,6 @@
 # `defineLayout`
 
-This function can be used to define the current [persistent layout](../../guide/pages-and-layouts.md#persistent-layouts), and, optionally, its properties.
+This function can be used to define the current [persistent layout](../../guide/views-and-layouts.md#persistent-layouts), and, optionally, its properties.
 
 | Related                                           | [`defineLayoutProperties`](./define-layout-properties.md) |
 | ------------------------------------------------- | --------------------------------------------------------- |

--- a/docs/api/utils/use-property.md
+++ b/docs/api/utils/use-property.md
@@ -24,9 +24,9 @@ useHead({
 })
 ```
 
-### Accessing page properties
+### Accessing view properties
 
-While `useProperty` is primarily made for accessing typed, global properties, you may provide a custom generic type to opt-out of global type-checking if you need to access page-specific properties.
+While `useProperty` is primarily made for accessing typed, global properties, you may provide a custom generic type to opt-out of global type-checking if you need to access view-specific properties.
 
 ```ts
 const posts = useProperty<App.Data.Post[]>('posts')

--- a/docs/api/utils/use-refinements.md
+++ b/docs/api/utils/use-refinements.md
@@ -22,7 +22,7 @@ function useRefinements<
 )
 ```
 
-`useRefinements` accepts the page's `$props` object as its first parameter and the name of the `Refinement` object's property as the second. As its optional third parameter, it accepts a list of [request options](../router/options.md).
+`useRefinements` accepts the view's `$props` object as its first parameter and the name of the `Refinement` object's property as the second. As its optional third parameter, it accepts a list of [request options](../router/options.md).
 
 ## Example
 

--- a/docs/api/utils/use-table.md
+++ b/docs/api/utils/use-table.md
@@ -22,7 +22,7 @@ function useTable<
 )
 ```
 
-`useTable` accepts the page's `$props` object as its first parameter and the name of the `Table` object's property as the second. As its optional third parameter, it accepts a list of [request options](../router/options.md).
+`useTable` accepts the view's `$props` object as its first parameter and the name of the `Table` object's property as the second. As its optional third parameter, it accepts a list of [request options](../router/options.md).
 
 ## Example
 

--- a/docs/configuration/laravel.md
+++ b/docs/configuration/laravel.md
@@ -82,9 +82,9 @@ This directory is used by the `@` import alias and for some of the integrations,
 
 ## Eager-loading views
 
-By default, Hybridly will eager-load page components, which means that users will have to load all views at once when accessing the application.
+By default, Hybridly will eager-load view components, which means that users will have to load all views at once when accessing the application.
 
-This is a good default, but if your application has a lot of pages, you may need to disable eager-loading, so views can be lazy-loaded as needed by your users.
+This is a good default, but if your application has a lot of views, you may need to disable eager-loading, so views can be lazy-loaded as needed by your users.
 
 To do that, simply set `architecture.eager_load_views` to `false`.
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -21,7 +21,7 @@ resources/
 │   └── root.blade.php
 ├── layouts/
 │   └── default.vue
-├── pages/
+├── views/
 │   ├── index.vue
 │   └── security/
 │       ├── register.vue
@@ -30,7 +30,7 @@ resources/
 └── composables/
 ```
 
-- Page components are located in `resources/pages` and may be nested.
+- view components are located in `resources/views` and may be nested.
 - Layout components are located in `resources/layouts`.
 - Util functions and composables are auto-imported.
 - The base Blade template is located at `resources/application/root.blade.php`.
@@ -43,7 +43,7 @@ You may use the predefined modular architecture using the `architecture.preset` 
 
 When the `architecture.preset` option is set to `modules`, directories in `resources/domains` will be considered as modules. 
 
-Pages and layouts will be loaded from the `pages` and `layouts` subdirectories, while TypeScript files will be auto-imported from `utils` and `composables`.
+Views and layouts will be loaded from the `views` and `layouts` subdirectories, while TypeScript files will be auto-imported from `utils` and `composables`.
 
 ```
 resources/
@@ -54,7 +54,7 @@ resources/
     └── security/
         ├── layouts/
         │   └── default.vue
-        ├── pages/
+        ├── views/
         │   ├── login.vue
         │   └── register.vue
         ├── utils/
@@ -91,7 +91,7 @@ src/
     │   └── ProcessPayment.php
     ├── Models/
     │   └── Invoice.php
-    ├── pages/  // [!code hl:8]
+    ├── views/  // [!code hl:8]
     │   ├── index.vue
     │   └── invoices/
     │       ├── index.vue

--- a/docs/guide/comparison-with-inertia.md
+++ b/docs/guide/comparison-with-inertia.md
@@ -24,12 +24,12 @@ The following is a non-exhaustive comparison table between Inertia and Hybridly'
 | Dot notation support for partial properties     |            <span class="no">No</span>             |                            Yes                             |
 | Infinite scrolling support                      |            <span class="no">No</span>             |        [Yes](../api/router/options.md#preserveurl)         |
 | Custom architecture support                     |            <span class="no">No</span>             |              [Yes](../guide/architecture.md)               |
-| Persistent layout                               |                        Yes                        |  [Yes](../guide/pages-and-layouts.md#persistent-layouts)   |
+| Persistent layout                               |                        Yes                        |       [Yes](views-and-layouts.md#persistent-layouts)       |
 | Persistent layout properties                    |            <span class="no">No</span>             |      [Yes](../api/utils/define-layout-properties.md)       |
 | Vite integration                                |            <span class="no">No</span>             |              [Yes](../configuration/vite.md)               |
 | Auto-imports                                    |            <span class="no">No</span>             |        [Yes](../configuration/vite.md#auto-imports)        |
 | Icons support                                   |            <span class="no">No</span>             |           [Yes](../configuration/vite.md#icons)            |
-| `layout` support in templates                   |            <span class="no">No</span>             |            [Yes](../guide/pages-and-layouts.md)            |
+| `layout` support in templates                   |            <span class="no">No</span>             |                [Yes](views-and-layouts.md)                 |
 | Built-in `form` util                            |                        Yes                        |              [Yes](../api/utils/use-form.md)               |
 | Built-in `route` util with TypeScript support   |            <span class="no">No</span>             |                [Yes](../api/utils/route.md)                |
 | Built-in `can` util with TypeScript support     |            <span class="no">No</span>             |                 [Yes](../api/utils/can.md)                 |

--- a/docs/guide/devtools.md
+++ b/docs/guide/devtools.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Vue plugin provided by Hybridly integrates with Vue DevTools. It makes debugging hybrid pages convenient.
+The Vue plugin provided by Hybridly integrates with Vue DevTools. It makes debugging hybrid views convenient.
 
 Make sure the [Vue DevTools](https://devtools.vuejs.org/) extension is installed in your browser, and open the Vue tab in the developer tools. Selecting any component will show a `hybridly` section with the active component name, properties, asset version, url and the routes registered by the router.
 

--- a/docs/guide/dialogs.md
+++ b/docs/guide/dialogs.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-Dialogs are components with their own URL and properties, which are rendered as siblings to page components.
+Dialogs are components with their own URL and properties, which are rendered as siblings to view components.
 
-When navigating from a page to a dialog, its component will be mounted as a sibling to the current page component — but when navigated to directly via their URL, the base page's component and properties will be loaded first, so the dialog can be rendered on top of it.
+When navigating from a view to a dialog, its component will be mounted as a sibling to the current view component—but when navigated to directly via their URL, the base view component and properties will be loaded first, so the dialog can be rendered on top of it.
 
 :::info Experimental
 This feature is experimental. Use with caution and feel free to report issues on our Discord server.
@@ -15,7 +15,7 @@ This feature is experimental. Use with caution and feel free to report issues on
 Dialogs may be anything you want — most commonly, they will be modals or slideovers. The following component is an example of a dialog component which is shown as a modal. 
 
 :::code-group
-```vue [pages/chirps/edit.vue]
+```vue [views/chirps/edit.vue]
 <script setup lang="ts">
 defineProps<{
   chirp: App.Data.ChirpData
@@ -108,9 +108,9 @@ Notice the call to [`unmount`](../api/utils/use-dialog.md#unmount), which is nee
 
 ## Rendering a dialog
 
-Dialogs are rendered the same as normal page components, but need a base page which can be defined by calling the [`base`](../api/laravel/hybridly.md#base) method on the view factory.
+Dialogs are rendered the same as normal view components, but need a base view which can be defined by calling the [`base`](../api/laravel/hybridly.md#base) method on the view factory.
 
-The `base` method takes the name of a route and its parameters are arguments. When the dialog is accessed directly via its URL, this route will be used to determine which background page should be used.
+The `base` method takes the name of a route and its parameters are arguments. When the dialog is accessed directly via its URL, this route will be used to determine which background view should be used.
 
 ```php
 use App\Data\ChirpData;

--- a/docs/guide/exception-handling.md
+++ b/docs/guide/exception-handling.md
@@ -10,9 +10,9 @@ In other words, Laravel's exception handling keeps working as expected, and the 
 
 In production, it's necessary to extend the exception handler so it returns a valid hybrid response even when an exception has been thrown.
 
-Usually, this consists of returning an `error` page component with the exception's details.
+Usually, this consists of returning an `error` view component with the exception's details.
 
-Hybridly makes this fairly simple by providing a `HandlesHybridExceptions` trait. When adding this trait to the exception handler, the `renderHybridResponse` method should be overriden to return the `error` page component.
+Hybridly makes this fairly simple by providing a `HandlesHybridExceptions` trait. When adding this trait to the exception handler, the `renderHybridResponse` method should be overriden to return the `error` view component.
 
 ```php
 namespace App\Exceptions;
@@ -34,7 +34,7 @@ class Handler extends ExceptionHandler
     ];
 
     /**
-     * Returns a hybrid page that renders the exception.
+     * Returns a hybrid view that renders the exception.
      */
     protected function renderHybridResponse(Response $response, Request $request, \Throwable $e): HybridResponse
     {
@@ -86,7 +86,7 @@ class Handler extends ExceptionHandler
     protected $skipEnvironments = ['test'];
 
     /**
-     * Returns a hybrid page that renders the exception.
+     * Returns a hybrid view that renders the exception.
      */
     protected function renderHybridResponse(Response $response, Request $request, \Throwable $e): HybridResponse
     {

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -45,7 +45,7 @@ const login = useForm({ // [!code focus:8]
 ```
 
 :::info Hybrid responses
-Note that no arbitrary data can be returned from a hybrid request. Instead, you should redirect back to a page — which can totally be the same page the request comes from.
+Note that no arbitrary data can be returned from a hybrid request. Instead, you should redirect back to a page—which can totally be the same page the request comes from.
 :::
 
 ## Form options

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -171,7 +171,7 @@ That middleware is, by default, located in `app/Http/Middleware/HandleHybridRequ
 
 ### Create `root.blade.php`
 
-Hybridly needs a `root.blade.php` file that will be loaded on the first page render. The name and path are configurable, but it's a good default.
+Hybridly needs a `root.blade.php` file that will be loaded on the initial page load. The name and path are configurable, but it's a good default.
 
 Proceed to delete `resources/views`, and create `resources/application/root.blade.php`. It needs to contain the `@hybridly` directive and to load assets.
 
@@ -265,9 +265,9 @@ Your project needs a `tsconfig.json` file to understand objects such as `import.
 
 The [TypeScript documentation](https://www.typescriptlang.org/tsconfig) is a good place to understand the configuration options that are available in this file.
 
-### Create a page component
+### Create a view component
 
-It's almost done. We just need a page component and a route to serve it. Create a `resources/pages/index.vue` file. A page component is a standard Vue component, except it's now a page component.
+It's almost done. We just need a view component and a route to serve it. Create a `resources/views/index.vue` file. A view component is a standard Vue component, except it's now a view component.
 
 ```vue
 <script setup lang="ts">
@@ -283,7 +283,7 @@ It's almost done. We just need a page component and a route to serve it. Create 
 
 ### Create a route
 
-In `routes/web.php`, you can now instruct a route to load your new page component. You just need to give its name to the `hybridly` function.
+In `routes/web.php`, you can now instruct a route to load your new view component. You just need to give its name to the `hybridly` function.
 
 ```php
 Route::get('/', function () {
@@ -304,6 +304,6 @@ open https://hybridly-app.test
 
 You may want to look into setting up [PHP to TypeScript transformation](../guide/typescript.md).
 
-To get started with building your application, you should read how to [pass data from the server](../guide/responses.md) to the front-end or how to [navigate between pages](../guide/navigation.md).
+To get started with building your application, you should read how to [pass data from the server](../guide/responses.md) to the front-end or how to [navigate between views](../guide/navigation.md).
 
 Feel free to explore the whole documentation before committing to Hybridly. Have fun building your applications!

--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -40,7 +40,7 @@ Learn more about the functions and options available in their [API documentation
 
 ## Preloading requests
 
-Preloading pages will perform the usual underlying AJAX request, but instead of following-up with the navigation, Hybridly will cache the request result until the navigation is actually required.
+Preloading views will perform the usual underlying AJAX request, but instead of following-up with the navigation, Hybridly will cache the request result until the navigation is actually required.
 
 This results in a smoother, snappy user experience that may make your application more enjoyable to use.
 

--- a/docs/guide/partial-reloads.md
+++ b/docs/guide/partial-reloads.md
@@ -4,7 +4,7 @@
 
 Partial reloads are repeated requests to the same page which purpose is to update or fetch specific properties, but not all of them. 
 
-As an example, consider a page that includes a list of users, as well as an option to filter the users by their company. On the first request to the page, both the `users` and `companies` properties are passed to the page component.
+As an example, consider a page that includes a list of users, as well as an option to filter the users by their company. On the first request to the page, both the `users` and `companies` properties are passed to the view component.
 
 However, on subsequent requests to the same page—maybe to filter the users—you can request only the `users` property from the server, and not the `companies` one.
 
@@ -80,7 +80,7 @@ onMounted(() => {
 })
 ```
 
-Deferred properties are the exact same as [partial properties](#partial-only-properties), except they also trigger an automatic partial reload specifically for them after the page component has loaded.
+Deferred properties are the exact same as [partial properties](#partial-only-properties), except they also trigger an automatic partial reload specifically for them after the view component has loaded.
 
 
 ## Lazy evaluation

--- a/docs/guide/preserving-urls.md
+++ b/docs/guide/preserving-urls.md
@@ -6,7 +6,7 @@ Hybrid responses return an `url` property. This is what allows hybrid applicatio
 
 ## Infinite scrolling
 
-In almost all situations, this makes perfect sense. However, when consuming pagination through infinite scrolling, it is not desired to update the URL with the `?page` query parameters, because — aside from being aesthetically unpleasant — reloading the page using the browser would skip the previous paginations, only showing the content for the current pagination index.
+In almost all situations, this makes perfect sense. However, when consuming pagination through infinite scrolling, it is not desired to update the URL with the `?page` query parameters, because — aside from being aesthetically unpleasant—reloading the page using the browser would skip the previous paginations, only showing the content for the current pagination index.
 
 For this reason, it's possible to preserve the URL of the current page after a request instead of updating it.
 

--- a/docs/guide/responses.md
+++ b/docs/guide/responses.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Hybrid responses respect a protocol to which the front-end adapter must adhere. A response contains, among other things, the name of the page component and its properties.
+Hybrid responses respect a protocol to which the front-end adapter must adhere. A response contains, among other things, the name of the view component and its properties.
 
 To send a response, use the [`hybridly`](../api/laravel/functions.md#hybridly) or the [`Hybridly\view`](../api/laravel/functions.md#view) functions the same way you would use `view`:
 

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -26,7 +26,7 @@ Learn more about sending responses in the [their documentation](./responses.md).
 
 ## Generating URLs
 
-Since pages are written in single-file components, global Laravel or PHP functions like `route` are not available.
+Since views are written in single-file components, global Laravel or PHP functions like `route` are not available.
 
 Instead, you may use Hybridly's [`route`](../api/utils/route) util. This function is typed and its typings are updated live as your `routes/*.php` files are saved.
 

--- a/docs/guide/title-and-meta.md
+++ b/docs/guide/title-and-meta.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Hybridly doesn't ship with any tool to manage the `title` or other `meta` tags of your pages. Instead, we recommend using [`@unhead/vue`](https://unhead.unjs.io/). It is simple of use and supports SSR.
+Hybridly doesn't ship with any tool to manage the `title` or other `meta` tags of your views. Instead, we recommend using [`@unhead/vue`](https://unhead.unjs.io/). It is simple of use and supports SSR.
 
 ## Installation
 
@@ -34,7 +34,7 @@ initializeHybridly({
 
 The latest `useHead` call is persisted, which means you may override `titleTemplate` on a layout. 
 
-Page titles may be defined using the `title` property in page components.
+Page titles may be defined using the `title` property in view components.
 
 :::code-group
 ```vue [layouts/default.vue]
@@ -58,7 +58,7 @@ useHead({
 </script>
 
 <template layout="default">
-  <!-- Page component -->
+  <!-- view component -->
 </template>
 ```
 :::

--- a/docs/guide/upgrade/0.1.x.md
+++ b/docs/guide/upgrade/0.1.x.md
@@ -2,11 +2,11 @@
 
 This guide describes how to upgrade from `v0.0.1-alpha` to `v0.1.0`.
 
-## Moving pages and layouts
+## Moving views and layouts
 
 - **Likelihood of impact**: <span class="text-red-700 dark:text-red-300">high</span>
 
-Previously, the expected emplacement for both page components and layouts was in `resources/views`. This has now moved to `resources`, so you should move them here.
+Previously, the expected emplacement for both view components and layouts was in `resources/views`. This has now moved to just `resources`, so you should move them here.
 
 ```diff
   resources/
@@ -41,7 +41,7 @@ initializeHybridly({
 })
 ```
 
-The `pages` option is automatically setup according to the optional `hybridly.config.ts` configuration file. To enable or disable eager-loading of page components, you may use the `eager` option in that file.
+The `pages` option is automatically setup according to the optional `hybridly.config.ts` configuration file. To enable or disable eager-loading of view components, you may use the `eager` option in that file.
 
 ## Updating `vite.config.ts`
 

--- a/docs/guide/views-and-layouts.md
+++ b/docs/guide/views-and-layouts.md
@@ -1,17 +1,17 @@
-# Pages and layouts
+# Views and layouts
 
 ## Overview
 
-With Hybridly, a page in your application consists of a regular <a href="https://vuejs.org/guide/scaling-up/sfc.html">single-file component</a>.
+With Hybridly, a view in your application consists of a regular <a href="https://vuejs.org/guide/scaling-up/sfc.html">single-file component</a>.
 
-Serving a page consists of returning a [hybrid response](./responses.md) with the component name and optional properties.
+Serving a view consists of returning a [hybrid response](./responses.md) with the component name and optional properties.
 
-## Pages
+## Views
 
-Pages are basic single-file components that can receive data from controllers as their properties. You can access these properties like any other single-file component using `defineProps`.
+Views are basic single-file components that can receive data from controllers as their properties. You can access these properties like any other single-file component using `defineProps`.
 
 :::code-group
-```vue [resources/views/pages/users/show.vue]
+```vue [resources/views/views/users/show.vue]
 <script setup lang="ts">
 const $props = defineProps<{
   user: App.Data.User
@@ -31,7 +31,7 @@ useHead({
 ```
 :::
 
-The route and controller for the page above could look like the following:
+The route and controller for the view above could look like the following:
 
 :::code-group
 ```php [web.php]
@@ -55,7 +55,7 @@ class ShowUserController
 
 ## Layouts
 
-A page layout can be a basic single-file component as well. You can simply wrap your page's content in the layout component, like you would do in a basic Vue project.
+A view layout can be a basic single-file component as well. You can simply wrap your view's content in the layout component, like you would do in a basic Vue project.
 
 ```vue
 <script setup lang="ts">
@@ -69,13 +69,13 @@ import MainLayout from '@/views/layouts/main.vue'
 </template>
 ```
 
-However, this technique has a drawback: when navigating between pages, the layout will be destroyed and re-mounted. This means you cannot have persistent state in it.
+However, this technique has a drawback: when navigating between views, the layout will be destroyed and re-mounted. This means you cannot have persistent state in it.
 
 ## Persistent layouts
 
-Persistent layouts are components that will not get destroyed upon navigation. Their state will be persisted when changing pages.
+Persistent layouts are components that will not get destroyed upon navigation. Their state will be persisted when changing views.
 
-A persistent layout can be defined in two ways. You can use the `layout` attribute on the `template` element of the page component:
+A persistent layout can be defined in two ways. You can use the `layout` attribute on the `template` element of the view component:
 
 ```vue
 <template layout="main">
@@ -114,12 +114,12 @@ Persistent layouts also have their own drawbacks. Specifically, it is not possib
 
 ## Persistent layout properties
 
-Additional properties can be passed to persistent layouts on a per-page basis. When navigating away from a page, the properties will be reset. 
+Additional properties can be passed to persistent layouts on a per-view basis. When navigating away from a view, the properties will be reset. 
 
 You may use the `defineLayoutProperties` util to define the layout properties:
 
 ```vue
-<!-- resources/views/pages/example.vue -->
+<!-- resources/views/views/example.vue -->
 <script setup lang="ts">
 defineLayoutProperties({
 	fluid: true,

--- a/docs/guide/visual-studio-code.md
+++ b/docs/guide/visual-studio-code.md
@@ -26,10 +26,10 @@ When using Laravel or Hybridly's `route` functions, the route name will be linki
 
 ### Component linking and auto-completion
 
-When rendering a page with the `hybridly` function, the page name will be linkified to its corresponding single-file component.
+When rendering a view with the `hybridly` function, the view component name will be linkified to its corresponding single-file component.
 
 <img
   src="../assets/vscode-component.jpg"
-  alt="Linkified page components"
+  alt="Linkified view components"
   class="rounded-lg shadow-lg mt-8"
 />

--- a/packages/core/src/external.ts
+++ b/packages/core/src/external.ts
@@ -42,7 +42,7 @@ export function isExternalResponse(response: AxiosResponse): boolean {
 }
 
 /**
- * Performs the internal navigation when an external navigation to a hybrid page has been made.
+ * Performs the internal navigation when an external navigation to a hybrid view has been made.
  * This method is meant to be called on router creation.
  */
 export async function handleExternalNavigation(): Promise<void> {

--- a/packages/core/src/plugins/hooks.ts
+++ b/packages/core/src/plugins/hooks.ts
@@ -71,7 +71,7 @@ export interface Hooks extends RequestHooks {
 	initialized: (context: InternalRouterContext) => MaybePromise<any>
 
 	/**
-	 * Called after Hybridly's initial page load.
+	 * Called after Hybridly's initial load.
 	 */
 	ready: (context: InternalRouterContext) => MaybePromise<any>
 

--- a/packages/core/src/router/router.ts
+++ b/packages/core/src/router/router.ts
@@ -363,7 +363,7 @@ export async function navigate(options: InternalNavigationOptions) {
 	}
 
 	// If there are deferred properties, we handle them
-	// by making a partial-reload after the page component has mounted
+	// by making a partial-reload after the view component has mounted
 	if (context.view.deferred?.length) {
 		debug.router('Request has deferred properties, queueing a partial reload:', context.view.deferred)
 		context.adapter.executeOnMounted(async() => {
@@ -453,7 +453,7 @@ async function initializeRouter(): Promise<InternalRouterContext> {
 	} else if (isExternalNavigation()) {
 		handleExternalNavigation()
 	} else {
-		debug.router('Handling the initial page navigation.')
+		debug.router('Handling the initial navigation.')
 
 		// If we navigated to somewhere with a hash, we need to update the context
 		// to add said hash because it was initialized without it.

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -23,7 +23,7 @@ export interface ComponentNavigationOptions {
 	replace?: ConditionalNavigationOption<boolean>
 	/** Whether to preserve the current scrollbar position. */
 	preserveScroll?: ConditionalNavigationOption<boolean>
-	/** Whether to preserve the current page component state. */
+	/** Whether to preserve the current view component state. */
 	preserveState?: ConditionalNavigationOption<boolean>
 }
 
@@ -35,9 +35,9 @@ export interface NavigationOptions {
 	 * one. This affects the browser's "back" and "forward" features.
 	 */
 	replace?: ConditionalNavigationOption<boolean>
-	/** Whether to preserve the scrollbars positions on the page. */
+	/** Whether to preserve the scrollbars positions on the view. */
 	preserveScroll?: ConditionalNavigationOption<boolean>
-	/** Whether to preserve the current page component's state. */
+	/** Whether to preserve the current view component's state. */
 	preserveState?: ConditionalNavigationOption<boolean>
 	/** Whether to preserve the current URL. */
 	preserveUrl?: ConditionalNavigationOption<boolean>
@@ -61,7 +61,7 @@ export interface NavigationOptions {
 export interface InternalNavigationOptions extends NavigationOptions {
 	/**
 	 * Defines the kind of navigation being performed.
-	 * - initial: the initial page load's navigation
+	 * - initial: the initial load's navigation
 	 * - server: a navigation initiated by a server round-trip
 	 * - local: a navigation initiated by `router.local`
 	 * - back-forward: a navigation initiated by the browser's `popstate` event
@@ -182,7 +182,7 @@ export interface PendingNavigation {
 |--------------------------------------------------------------------------
 */
 
-/** A page or dialog component. */
+/** A view or dialog component. */
 export interface View {
 	/** Name of the component to use. */
 	component?: string
@@ -193,7 +193,7 @@ export interface View {
 }
 
 export interface Dialog extends Required<View> {
-	/** URL that is the base background page when navigating to the dialog directly. */
+	/** URL that is the base background view when navigating to the dialog directly. */
 	baseUrl: string
 	/** URL to which the dialog should redirect when closed. */
 	redirectUrl: string

--- a/packages/core/src/scroll.ts
+++ b/packages/core/src/scroll.ts
@@ -3,7 +3,7 @@ import { SCROLL_REGION_ATTRIBUTE } from './constants'
 import { getRouterContext, setContext } from './context'
 import { setHistoryState } from './router/history'
 
-/** Saves the current page's scrollbar positions into the history state. */
+/** Saves the current view's scrollbar positions into the history state. */
 export function saveScrollPositions(): void {
 	const regions = getScrollRegions()
 	debug.scroll('Saving scroll positions of:', regions.map((el) => ({ el, scroll: { top: el.scrollTop, left: el.scrollLeft } })))
@@ -29,7 +29,7 @@ export function getScrollRegions(): Element[] {
 }
 
 /**
- * Resets the current page's scrollbars positions to the top, and save them
+ * Resets the current view's scrollbars positions to the top, and save them
  * in the history state.
  */
 export function resetScrollPositions(): void {

--- a/packages/laravel/config/hybridly.php
+++ b/packages/laravel/config/hybridly.php
@@ -98,10 +98,10 @@ return [
     |--------------------------------------------------------------------------
     | Testing
     |--------------------------------------------------------------------------
-    | When `ensure_pages_exist` is enabled, Hybridly will ensure that pages
+    | When `ensure_views_exist` is enabled, Hybridly will ensure that views
     | actually exist on the disk when hybrid testing utilities are used.
     */
     'testing' => [
-        'ensure_pages_exist' => true,
+        'ensure_views_exist' => true,
     ],
 ];

--- a/packages/laravel/src/Concerns/ForwardsToHybridlyHelpers.php
+++ b/packages/laravel/src/Concerns/ForwardsToHybridlyHelpers.php
@@ -42,8 +42,8 @@ trait ForwardsToHybridlyHelpers
     }
 
     /**
-     * Generates a response for redirecting to an external website, or a non-hybrid page.
-     * This can also be used to redirect to a hybrid page when it is not known whether the current request is hybrid or not.
+     * Generates a response for redirecting to an external website, or a non-hybrid view.
+     * This can also be used to redirect to a hybrid view when it is not known whether the current request is hybrid or not.
      *
      * @see https://hybridly.dev/api/laravel/hybridly.html#external
      */

--- a/packages/laravel/src/Concerns/HandlesHybridExceptions.php
+++ b/packages/laravel/src/Concerns/HandlesHybridExceptions.php
@@ -55,7 +55,7 @@ trait HandlesHybridExceptions
     }
 
     /**
-     * Returns a hybrid page that renders the exception.
+     * Returns a hybrid view that renders the exception.
      */
     protected function renderHybridResponse(Response $response, Request $request, \Throwable $e): HybridResponse
     {

--- a/packages/laravel/src/Concerns/HasViewFinder.php
+++ b/packages/laravel/src/Concerns/HasViewFinder.php
@@ -52,7 +52,7 @@ trait HasViewFinder
     }
 
     /**
-     * Loads a namespaced module and its pages, layouts and components.
+     * Loads a namespaced module and its views, layouts and components.
      *
      * @see https://hybridly.dev/api/laravel/hybridly.html#loadmodulefrom
      */
@@ -63,13 +63,13 @@ trait HasViewFinder
         }
 
         $namespace ??= str($directory)->basename()->kebab();
-        $pagesDirectory = config('hybridly.architecture.pages_directory', 'pages');
+        $viewsDirectory = config('hybridly.architecture.views_directory', 'views');
         $layoutsDirectory = config('hybridly.architecture.layouts_directory', 'layouts');
         $componentsDirectory = config('hybridly.architecture.components_directory', 'components');
 
         $this->getViewFinder()->loadDirectory($directory);
 
-        rescue(fn () => $this->getViewFinder()->loadViewsFrom($directory . '/' . $pagesDirectory, $namespace), report: false);
+        rescue(fn () => $this->getViewFinder()->loadViewsFrom($directory . '/' . $viewsDirectory, $namespace), report: false);
         rescue(fn () => $this->getViewFinder()->loadLayoutsFrom($directory . '/' . $layoutsDirectory, $namespace), report: false);
         rescue(fn () => $this->getViewFinder()->loadComponentsFrom($directory . '/' . $componentsDirectory, $namespace), report: false);
 

--- a/packages/laravel/src/Http/Middleware.php
+++ b/packages/laravel/src/Http/Middleware.php
@@ -127,7 +127,7 @@ class Middleware
     }
 
     /**
-     * Sets the root template that's loaded on the first page load.
+     * Sets the root template that's loaded on the initial page load.
      */
     public function rootView(Request $request): \Closure|string
     {

--- a/packages/laravel/src/Support/Deferred.php
+++ b/packages/laravel/src/Support/Deferred.php
@@ -3,7 +3,7 @@
 namespace Hybridly\Support;
 
 /**
- * Represents a property that will automatically get evaluated in a subsequent partial reload after the page has loaded.
+ * Represents a property that will automatically get evaluated in a subsequent partial reload after the view has loaded.
  */
 class Deferred extends Partial
 {

--- a/packages/laravel/src/Support/helpers.php
+++ b/packages/laravel/src/Support/helpers.php
@@ -109,8 +109,8 @@ if (!\function_exists('Hybridly\deferred')) {
 
 if (!\function_exists('Hybridly\to_external_url')) {
     /**
-     * Generates a response for redirecting to an external website, or a non-hybrid page.
-     * This can also be used to redirect to a hybrid page when it is not known whether the current request is hybrid or not.
+     * Generates a response for redirecting to an external website, or a non-hybrid view.
+     * This can also be used to redirect to a hybrid view when it is not known whether the current request is hybrid or not.
      *
      * @see https://hybridly.dev/api/laravel/functions.html#to-external-url
      */

--- a/packages/laravel/src/Testing/Assertable.php
+++ b/packages/laravel/src/Testing/Assertable.php
@@ -46,18 +46,18 @@ class Assertable extends AssertableJson
         return $instance;
     }
 
-    public function view(string $value = null, $shouldExist = null): self
+    public function assertViewComponent(string $value = null, bool $shouldExist = null): self
     {
-        PHPUnit::assertSame($value, $this->view, 'Unexpected Hybridly page view.');
+        PHPUnit::assertSame($value, $this->view, 'Unexpected hybrid view component.');
 
-        if ($shouldExist || (\is_null($shouldExist) && config('hybridly.testing.ensure_pages_exist', true))) {
-            $this->ensurePageExists($value);
+        if ($shouldExist || (\is_null($shouldExist) && config('hybridly.testing.ensure_views_exist', true))) {
+            $this->ensureViewExists($value);
         }
 
         return $this;
     }
 
-    public function dialog(array $properties = null, string $view = null, string $baseUrl = null, string $redirectUrl = null): self
+    public function assertDialog(array $properties = null, string $view = null, string $baseUrl = null, string $redirectUrl = null): self
     {
         PHPUnit::assertNotNull($this->dialog, 'There is no dialog.');
 
@@ -72,8 +72,8 @@ class Assertable extends AssertableJson
         if ($view) {
             PHPUnit::assertSame($view, $this->dialog['component'], 'Unexpected dialog view component.');
 
-            if (config('hybridly.testing.ensure_pages_exist', true)) {
-                $this->ensurePageExists($view);
+            if (config('hybridly.testing.ensure_views_exist', true)) {
+                $this->ensureViewExists($view);
             }
         }
 
@@ -84,14 +84,14 @@ class Assertable extends AssertableJson
         return $this;
     }
 
-    public function url(string $value): self
+    public function assertViewUrl(string $value): self
     {
-        PHPUnit::assertSame($value, $this->url, 'Unexpected Hybridly page url.');
+        PHPUnit::assertSame($value, $this->url, 'Unexpected Hybridly view URL.');
 
         return $this;
     }
 
-    public function version(string $value): self
+    public function assertHybridVersion(string $value): self
     {
         PHPUnit::assertSame($value, $this->version, 'Unexpected Hybridly asset version.');
 
@@ -194,7 +194,7 @@ class Assertable extends AssertableJson
         return $this->getPayload();
     }
 
-    protected function ensurePageExists(string $identifier): void
+    protected function ensureViewExists(string $identifier): void
     {
         try {
             resolve(Hybridly::class)->getViewFinder()->hasView($identifier);

--- a/packages/laravel/src/Testing/TestResponseMacros.php
+++ b/packages/laravel/src/Testing/TestResponseMacros.php
@@ -137,7 +137,7 @@ class TestResponseMacros
     {
         return function (string $view): TestResponse {
             /** @var TestResponse $this */
-            Assertable::fromTestResponse($this)->view($view);
+            Assertable::fromTestResponse($this)->assertViewComponent($view);
 
             return $this;
         };
@@ -150,7 +150,7 @@ class TestResponseMacros
     {
         return function (array $properties = null, string $view = null, string $baseUrl = null, string $redirectUrl = null): TestResponse {
             /** @var TestResponse $this */
-            Assertable::fromTestResponse($this)->dialog($properties, $view, $baseUrl, $redirectUrl);
+            Assertable::fromTestResponse($this)->assertDialog($properties, $view, $baseUrl, $redirectUrl);
 
             return $this;
         };
@@ -163,7 +163,7 @@ class TestResponseMacros
     {
         return function (string $version): TestResponse {
             /** @var TestResponse $this */
-            Assertable::fromTestResponse($this)->version($version);
+            Assertable::fromTestResponse($this)->assertHybridVersion($version);
 
             return $this;
         };
@@ -176,7 +176,7 @@ class TestResponseMacros
     {
         return function (string $url): TestResponse {
             /** @var TestResponse $this */
-            Assertable::fromTestResponse($this)->url($url);
+            Assertable::fromTestResponse($this)->assertViewUrl($url);
 
             return $this;
         };

--- a/packages/laravel/tests/Laravel/Testing/AssertableTest.php
+++ b/packages/laravel/tests/Laravel/Testing/AssertableTest.php
@@ -2,30 +2,30 @@
 
 use Hybridly\Testing\Assertable;
 
-test('the `view` method asserts that the view is the expected value', function () {
-    make_hybrid_mock_request()->assertHybrid(function (Assertable $page) {
-        $page->view('test');
+test('the `assertHybridViewComponent` method asserts that the view is the expected value', function () {
+    make_hybrid_mock_request()->assertHybrid(function (Assertable $view) {
+        $view->assertViewComponent('test');
     });
 });
 
-test('the `url` method asserts that the url is the expected value', function () {
-    make_hybrid_mock_request(url: '/url-to-a-hybrid-page')->assertHybrid(function (Assertable $page) {
-        $page->url(config('app.url') . '/url-to-a-hybrid-page');
+test('the `assertViewUrl` method asserts that the url is the expected value', function () {
+    make_hybrid_mock_request(url: '/url-to-a-page')->assertHybrid(function (Assertable $view) {
+        $view->assertViewUrl(config('app.url') . '/url-to-a-page');
     });
 });
 
-test('the `version` method asserts that the version is the expected value', function () {
+test('the `assertHybridVersion` method asserts that the version is the expected value', function () {
     hybridly()->setVersion('owo');
 
-    make_hybrid_mock_request()->assertHybrid(function (Assertable $page) {
-        $page->version('owo');
+    make_hybrid_mock_request()->assertHybrid(function (Assertable $view) {
+        $view->assertHybridVersion('owo');
     });
 });
 
 test('the `getPayload` method returns the payload', function () {
-    make_hybrid_mock_request()->assertHybrid(function (Assertable $page) {
-        expect($page->getPayload())->toBeArray();
-        expect($page->getPayload())->toHaveKeys([
+    make_hybrid_mock_request()->assertHybrid(function (Assertable $view) {
+        expect($view->getPayload())->toBeArray();
+        expect($view->getPayload())->toHaveKeys([
             'view',
             'view.component',
             'view.properties',
@@ -38,23 +38,23 @@ test('the `getPayload` method returns the payload', function () {
 
 test('the `getValue` method returns the value at the given path', function () {
     make_hybrid_mock_request(properties: ['foo' => 'bar'])
-        ->assertHybrid(function (Assertable $page) {
-            expect($page->getValue('view.component'))->toBe('test');
-            expect($page->getValue('view.properties.foo'))->toBe('bar');
+        ->assertHybrid(function (Assertable $view) {
+            expect($view->getValue('view.component'))->toBe('test');
+            expect($view->getValue('view.properties.foo'))->toBe('bar');
         });
 });
 
 test('the `getProperty` method returns the property value at the given path', function () {
     make_hybrid_mock_request(properties: ['foo' => 'bar'])
-        ->assertHybrid(function (Assertable $page) {
-            expect($page->getProperty('foo'))->toBe('bar');
+        ->assertHybrid(function (Assertable $view) {
+            expect($view->getProperty('foo'))->toBe('bar');
         });
 });
 
 test('the `toArray` function converts the Assertable instance to an array', function () {
-    make_hybrid_mock_request()->assertHybrid(function (Assertable $page) {
-        expect($page->toArray())->toBeArray();
-        expect($page->getPayload())->toHaveKeys([
+    make_hybrid_mock_request()->assertHybrid(function (Assertable $view) {
+        expect($view->toArray())->toBeArray();
+        expect($view->getPayload())->toHaveKeys([
             'view',
             'view.component',
             'view.properties',

--- a/packages/laravel/tests/Laravel/Testing/TestResponseMacrosTest.php
+++ b/packages/laravel/tests/Laravel/Testing/TestResponseMacrosTest.php
@@ -9,8 +9,8 @@ use function Pest\Laravel\get;
 test('the `assertHybrid` method runs its callback', function () {
     $success = false;
 
-    make_hybrid_mock_request()->assertHybrid(function (Assertable $page) use (&$success) {
-        expect($page)->toBeInstanceOf(Assertable::class);
+    make_hybrid_mock_request()->assertHybrid(function (Assertable $view) use (&$success) {
+        expect($view)->toBeInstanceOf(Assertable::class);
         $success = true;
     });
 
@@ -18,14 +18,14 @@ test('the `assertHybrid` method runs its callback', function () {
 });
 
 test('the `assertHybridDialog` method asserts dialog view component & base url & properties', function () {
-    Route::get('/test/page', fn () => hybridly('test.page'))->name('test.page');
-    Route::get('/test/dialog', fn () => hybridly('test.dialog', ['foo' => 'bar'])->base('test.page'))->name('test.dialog');
+    Route::get('/test/view', fn () => hybridly('test.view'))->name('test.view');
+    Route::get('/test/dialog', fn () => hybridly('test.dialog', ['foo' => 'bar'])->base('test.view'))->name('test.dialog');
 
     get('/test/dialog')
-        ->assertHybridView('test.page')
+        ->assertHybridView('test.view')
         ->assertHybridUrl('http://localhost/test/dialog')
         ->assertHybridDialog(
-            baseUrl: 'http://localhost/test/page',
+            baseUrl: 'http://localhost/test/view',
             view: 'test.dialog',
             properties: [
                 'foo' => 'bar',
@@ -137,12 +137,12 @@ test('the `assertHybrid` method returns a `TestResponse` instance', function () 
 test('the `getHybridPayload` method returns the payload of the hybrid response', function () {
     $response = make_hybrid_mock_request(properties: ['bar' => 'baz']);
 
-    tap($response->getHybridPayload(), function (array $page) {
-        expect($page['view']['component'])->toBe('test');
-        expect($page['view']['properties'])->toBe(['bar' => 'baz']);
-        expect($page['dialog'])->toBeNull();
-        expect($page['url'])->toBe(config('app.url') . '/hybrid-mock-url');
-        expect($page['version'])->toBeNull();
+    tap($response->getHybridPayload(), function (array $view) {
+        expect($view['view']['component'])->toBe('test');
+        expect($view['view']['properties'])->toBe(['bar' => 'baz']);
+        expect($view['dialog'])->toBeNull();
+        expect($view['url'])->toBe(config('app.url') . '/hybrid-mock-url');
+        expect($view['version'])->toBeNull();
     });
 });
 

--- a/packages/laravel/tests/Laravel/View/FactoryTest.php
+++ b/packages/laravel/tests/Laravel/View/FactoryTest.php
@@ -173,7 +173,7 @@ test('the url resolver is used when constructing a response', function () {
     ]);
 });
 
-test('hybridly responses without a page component', function () {
+test('hybridly responses without a view component', function () {
     hybridly()->setRootView(Hybridly::DEFAULT_ROOT_VIEW);
     hybridly()->setVersion('123');
 
@@ -198,7 +198,7 @@ test('hybridly responses without a page component', function () {
     ]);
 });
 
-test('hybridly responses without a page component on initial load', function () {
+test('hybridly responses without a view component on initial load', function () {
     hybridly()->setRootView(Hybridly::DEFAULT_ROOT_VIEW);
     hybridly()->setVersion('123');
 

--- a/packages/laravel/tests/Laravel/ViewFinder/ViewFinderTest.php
+++ b/packages/laravel/tests/Laravel/ViewFinder/ViewFinderTest.php
@@ -3,7 +3,7 @@
 use Hybridly\Support\VueViewFinder;
 use Illuminate\Support\Facades\File;
 
-function with_page_component(string $targetPath, \Closure $assertion): void
+function with_view_component(string $targetPath, \Closure $assertion): void
 {
     $path = str(resource_path())
         ->finish('/')
@@ -11,26 +11,26 @@ function with_page_component(string $targetPath, \Closure $assertion): void
         ->toString();
 
     File::makeDirectory(dirname($path), recursive: true, force: true);
-    File::copy(__DIR__ . '/../../stubs/page.vue', $path);
+    File::copy(__DIR__ . '/../../stubs/view.vue', $path);
     $assertion();
     File::cleanDirectory(dirname($path));
 }
 
 test('`hasView` determines if a view is registered', function (string $target, string $namespace, string $expectedIdentifier) {
-    with_page_component($target, function () use ($namespace, $expectedIdentifier) {
+    with_view_component($target, function () use ($namespace, $expectedIdentifier) {
         /** @var VueViewFinder */
         $viewFinder = resolve(VueViewFinder::class);
         $viewFinder->loadViewsFrom(
-            directory: resource_path('pages'),
+            directory: resource_path('views'),
             namespace: $namespace,
         );
 
         expect($viewFinder->hasView($expectedIdentifier))->toBeTrue();
     });
 })->with([
-    ['pages/my-page.tsx', 'default', 'my-page'],
-    ['pages/my-page.vue', 'default', 'my-page'],
-    ['pages/sub/my-page.vue', 'default', 'sub.my-page'],
-    ['pages/my-page.vue', 'custom', 'custom::my-page'],
-    ['pages/sub/my-page.vue', 'custom', 'custom::sub.my-page'],
+    ['views/my-view.tsx', 'default', 'my-view'],
+    ['views/my-view.vue', 'default', 'my-view'],
+    ['views/sub/my-view.vue', 'default', 'sub.my-view'],
+    ['views/my-view.vue', 'custom', 'custom::my-view'],
+    ['views/sub/my-view.vue', 'custom', 'custom::sub.my-view'],
 ]);

--- a/packages/laravel/tests/Pest.php
+++ b/packages/laravel/tests/Pest.php
@@ -11,7 +11,7 @@ use Illuminate\Testing\TestResponse;
 use function Pest\Laravel\get;
 
 uses(TestCase::class)
-    ->beforeEach(fn () => config()->set('hybridly.testing.ensure_pages_exist', false))
+    ->beforeEach(fn () => config()->set('hybridly.testing.ensure_views_exist', false))
     ->in(__DIR__);
 
 function mock_request(string $url = '/', string $method = 'GET', bool $bind = false, bool $hybridly = true, array $headers = []): Request

--- a/packages/utils/src/error-modal.ts
+++ b/packages/utils/src/error-modal.ts
@@ -37,29 +37,13 @@ class Modal {
 		`, id)
 	}
 
-	static forPageComponent(component: string, id: string) {
+	static forViewComponent(component: string, id: string) {
 		return new Modal(`
 			<style>${style()}</style>
 			<div class="h-full text-center flex">
 				<div class="m-auto">
 					<div class="text-5xl font-thin">Error</div>
-					<div class="opacity-30 text-lg font-thin m-1">The specified page component does not exist.</div>
-					<div class="m-2 flex justify-center text-xl opacity-30 underline underline-dotted">${component}</div>
-				</div>
-			</div>
-		`, id)
-	}
-
-	static domainsDisabled(component: string, id: string) {
-		return new Modal(`
-			<style>${style()}</style>
-			<div class="h-full text-center flex">
-				<div class="m-auto">
-					<div class="text-5xl font-thin">Error</div>
-					<div class="opacity-30 text-lg font-thin m-1">
-						A domain-based page component was specificed, but domains are disabled. <br />
-						Set <code>domains</code> to <code>true</code> in <a class="underline underline-dotted" href="https://hybridly.dev/configuration/architecture.html#domains"><code>hybridly.config.ts</code></a>.
-					</div>
+					<div class="opacity-30 text-lg font-thin m-1">The specified view component does not exist.</div>
 					<div class="m-2 flex justify-center text-xl opacity-30 underline underline-dotted">${component}</div>
 				</div>
 			</div>
@@ -169,12 +153,8 @@ export function showResponseErrorModal(response: string): Modal {
 	return Modal.fromException(response, 'non-hybrid-response')
 }
 
-export function showPageComponentErrorModal(response: string): Modal {
-	return Modal.forPageComponent(response, `page-component-${response}`)
-}
-
-export function showDomainsDisabledErrorModal(response: string): Modal {
-	return Modal.domainsDisabled(response, `domains-disabled-${response}`)
+export function showViewComponentErrorModal(response: string): Modal {
+	return Modal.forViewComponent(response, `view-component-${response}`)
 }
 
 function htmlStyle() {

--- a/packages/vite/src/config/index.ts
+++ b/packages/vite/src/config/index.ts
@@ -58,10 +58,10 @@ export default (options: ViteOptions, config: DynamicConfiguration): Plugin => {
 				// Force-reload the server when the routing or components change
 				if (/.*\.vue$/.test(file)) {
 					const updatedConfig = await loadConfiguration(options)
-					const pagesOrLayoutsChanged = didPagesOrLayoutsChange(updatedConfig, config)
+					const viewsOrLayoutsChanged = didViewsOrLayoutsChange(updatedConfig, config)
 
-					if (pagesOrLayoutsChanged) {
-						return await forceRestart('Page or layout changed')
+					if (viewsOrLayoutsChanged) {
+						return await forceRestart('View or layout changed')
 					}
 				}
 			}
@@ -89,7 +89,7 @@ export default (options: ViteOptions, config: DynamicConfiguration): Plugin => {
 	}
 }
 
-function didPagesOrLayoutsChange(updatedConfig: DynamicConfiguration, previousConfig?: DynamicConfiguration) {
+function didViewsOrLayoutsChange(updatedConfig: DynamicConfiguration, previousConfig?: DynamicConfiguration) {
 	if (!previousConfig) {
 		return false
 	}

--- a/packages/vue/src/composables/layout.ts
+++ b/packages/vue/src/composables/layout.ts
@@ -3,7 +3,7 @@ import { state } from '../stores/state'
 export type Layout = any
 
 /**
- * Sets the persistent layout for this page.
+ * Sets the persistent layout for this view.
  */
 export function defineLayout<T extends Record<string, K>, K = any>(layout: Layout, properties?: T): void
 export function defineLayout(layouts: Layout[]): void

--- a/packages/vue/src/composables/table.ts
+++ b/packages/vue/src/composables/table.ts
@@ -191,7 +191,7 @@ export function useTable<
 			/** Checks whether the column is filterable. */
 			isFilterable: refinements.filters.find((filters) => filters.name === column.name),
 		}))),
-		/** List of records for this page. */
+		/** List of records for this table. */
 		records: computed(() => table.value.records.map((record) => ({
 			/** The actual record. */
 			record,

--- a/packages/vue/src/initialize.ts
+++ b/packages/vue/src/initialize.ts
@@ -2,7 +2,7 @@ import type { App, DefineComponent, Plugin as VuePlugin } from 'vue'
 import { createApp, h } from 'vue'
 import type { DynamicConfiguration, Plugin, RouterContext, RouterContextOptions, RoutingConfiguration } from '@hybridly/core'
 import { createRouter } from '@hybridly/core'
-import { showPageComponentErrorModal, debug, random } from '@hybridly/utils'
+import { showViewComponentErrorModal, debug, random } from '@hybridly/utils'
 import type { Axios } from 'axios'
 import { type ProgressOptions, progress } from './plugins/progress'
 import { wrapper } from './components/wrapper'
@@ -157,8 +157,8 @@ async function resolveViewComponent(name: string, options: ResolvedInitializeOpt
 		.find((path) => result ? path.endsWith(result?.path) : false)
 
 	if (!result || !path) {
-		console.warn(`Page component [${name}] not found. Available components: `, options.components.views.map(({ identifier }) => identifier))
-		showPageComponentErrorModal(name)
+		console.warn(`View component [${name}] not found. Available components: `, options.components.views.map(({ identifier }) => identifier))
+		showViewComponentErrorModal(name)
 		return
 	}
 


### PR DESCRIPTION
This pull request improves consistency in both the code-base and the docs when it comes to using the "page" and "view" terms. 

As of now, "page" is used in the "browser page" sense, and "view" is used in the "presentation layer" sense.

**This PR introduces a breaking change**: previously, the `resources/pages` directory was loaded when using the default architecture, but now it's `resources/views`.