### PR TITLE
docs: createHead example correction

### DIFF
--- a/docs/guide/title-and-meta.md
+++ b/docs/guide/title-and-meta.md
@@ -22,9 +22,7 @@ import { createHead } from '@unhead/vue' // [!code hl]
 initializeHybridly({
   enhanceVue: (vue) => {
     const head = createHead()
-
     head.push({titleTemplate: (title) => title ? `${title} - Blue Bird` : 'Blue Bird'})
-
     vue.use(head)
   }
 })

--- a/docs/guide/title-and-meta.md
+++ b/docs/guide/title-and-meta.md
@@ -21,9 +21,11 @@ import { createHead } from '@unhead/vue' // [!code hl]
 
 initializeHybridly({
   enhanceVue: (vue) => {
-    vue.use(createHead({ // [!code hl:3]
-			titleTemplate: (title) => title ? `${title} - Blue Bird` : 'Blue Bird',
-		})) 
+    const head = createHead()
+
+    head.push({titleTemplate: (title) => title ? `${title} - Blue Bird` : 'Blue Bird'})
+
+    vue.use(head)
   }
 })
 ```
@@ -32,7 +34,7 @@ initializeHybridly({
 
 ## Usage
 
-The latest `useHead` call is persisted, which means you may override `titleTemplate` on a layout. 
+The latest `useHead` call is persisted, which means you may override `titleTemplate` on a layout.
 
 Page titles may be defined using the `title` property in view components.
 


### PR DESCRIPTION
Given `createHead` example with `titleTemplate` is not working. And, throwing this type error:

> Vue: Argument of type `{ titleTemplate: (title: any) => string;}`  is not assignable to parameter of type `CreateHeadOptions` Object literal may only specify known properties, and `titleTemplate` does not exist in type `CreateHeadOptions` 

So, I updated the example with different approach, and it worked. 