### PR TITLE
Yarn command typo fixes.

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -87,7 +87,7 @@ bun i hybridly vue axios -D
 npm i hybridly vue axios -D
 ```
 ```bash [yarn]
-yarn i hybridly vue axios -D
+yarn add hybridly vue axios -D
 ```
 :::
 

--- a/docs/guide/title-and-meta.md
+++ b/docs/guide/title-and-meta.md
@@ -22,9 +22,7 @@ import { createHead } from '@unhead/vue' // [!code hl]
 initializeHybridly({
   enhanceVue: (vue) => {
     const head = createHead()
-
     head.push({titleTemplate: (title) => title ? `${title} - Blue Bird` : 'Blue Bird'})
-
     vue.use(head)
   }
 })

--- a/docs/guide/title-and-meta.md
+++ b/docs/guide/title-and-meta.md
@@ -21,9 +21,11 @@ import { createHead } from '@unhead/vue' // [!code hl]
 
 initializeHybridly({
   enhanceVue: (vue) => {
-    vue.use(createHead({ // [!code hl:3]
-			titleTemplate: (title) => title ? `${title} - Blue Bird` : 'Blue Bird',
-		})) 
+    const head = createHead()
+
+    head.push({titleTemplate: (title) => title ? `${title} - Blue Bird` : 'Blue Bird'})
+
+    vue.use(head)
   }
 })
 ```
@@ -32,7 +34,7 @@ initializeHybridly({
 
 ## Usage
 
-The latest `useHead` call is persisted, which means you may override `titleTemplate` on a layout. 
+The latest `useHead` call is persisted, which means you may override `titleTemplate` on a layout.
 
 Page titles may be defined using the `title` property in view components.
 


### PR DESCRIPTION
On installation page yarn command has a typo error. it should be `yarn add hybridly vue axios -D` instead of `yarn i hybridly vue axios -D`