### PR TITLE
fix: put testing helpers in autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,23 +35,21 @@
     "autoload": {
         "files": [
             "packages/laravel/src/Support/global_helpers.php",
-            "packages/laravel/src/Support/helpers.php"
+            "packages/laravel/src/Support/helpers.php",
+            "packages/laravel/src/Testing/helpers.php"
         ],
         "psr-4": {
             "Hybridly\\": [
                 "packages/laravel/src"
-            ]
+            ],
+            "Hybridly\\Tests\\": "packages/laravel/tests"
         }
     },
     "autoload-dev": {
-        "files": [
-            "packages/laravel/src/Testing/helpers.php"
-        ],
         "psr-4": {
             "Build\\": [
                 "build"
-            ],
-            "Hybridly\\Tests\\": "packages/laravel/tests"
+            ]
         }
     },
     "extra": {


### PR DESCRIPTION
Load the testing helper in the `autoload` instead of `autoload-dev`.

https://getcomposer.org/doc/04-schema.md#autoload-dev
`autoload-dev` is root-only.