### PR TITLE
fix(tables): support invoking hidden actions

### DIFF
--- a/packages/laravel/src/Tables/Actions/Http/InvokedActionController.php
+++ b/packages/laravel/src/Tables/Actions/Http/InvokedActionController.php
@@ -51,8 +51,8 @@ final class InvokedActionController
         }
 
         $actions = match ($data::class) {
-            InlineActionData::class => $table->getInlineActions(),
-            BulkActionData::class => $table->getBulkActions(),
+            InlineActionData::class => $table->getInlineActions(showHidden: true),
+            BulkActionData::class => $table->getBulkActions(showHidden: true),
         };
 
         if (!$action = $actions->first(fn (BaseAction $action) => $action->getName() === $data->action)) {

--- a/packages/laravel/src/Tables/Concerns/HasActions.php
+++ b/packages/laravel/src/Tables/Concerns/HasActions.php
@@ -11,20 +11,21 @@ trait HasActions
 {
     protected mixed $cachedActions = null;
 
-    public function getActions(): Collection
+    public function getActions(bool $showHidden = false): Collection
     {
         return $this->cachedActions ??= collect($this->defineActions())
+            ->when(!$showHidden)
             ->filter(static fn (BaseAction $action): bool => !$action->isHidden());
     }
 
-    public function getInlineActions(): Collection
+    public function getInlineActions(bool $showHidden = false): Collection
     {
-        return $this->getActions()->filter(static fn (BaseAction $action): bool => $action instanceof InlineAction);
+        return $this->getActions($showHidden)->filter(static fn (BaseAction $action): bool => $action instanceof InlineAction);
     }
 
-    public function getBulkActions(): Collection
+    public function getBulkActions(bool $showHidden = false): Collection
     {
-        return $this->getActions()->filter(static fn (BaseAction $action): bool => $action instanceof BulkAction);
+        return $this->getActions($showHidden)->filter(static fn (BaseAction $action): bool => $action instanceof BulkAction);
     }
 
     protected function defineActions(): array

--- a/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithConditionallyHiddenStuff.php
+++ b/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithConditionallyHiddenStuff.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Hybridly\Tests\Laravel\Tables\Fixtures;
+
+use Hybridly\Refining\Filters\Filter;
+use Hybridly\Refining\Sorts\Sort;
+use Hybridly\Tables\Actions\BulkAction;
+use Hybridly\Tables\Actions\InlineAction;
+use Hybridly\Tables\Columns\TextColumn;
+use Hybridly\Tables\Table;
+use Hybridly\Tests\Fixtures\Database\Product;
+use Illuminate\Support\Collection;
+
+class BasicProductsTableWithConditionallyHiddenStuff extends Table
+{
+    protected string $model = Product::class;
+
+    public function defineRefiners(): array
+    {
+        return [
+            Sort::make('name')->hidden(),
+            Filter::make('name')->hidden(),
+        ];
+    }
+
+    public function defineActions(): array
+    {
+        return [
+            BulkAction::make('say_our_names')->action(fn (Collection $records) => $records->each(fn (Product $record) => $record->name))->hidden(!auth()->check()),
+            InlineAction::make('say_my_name')->action(fn (Product $record) => $record->name)->hidden(!auth()->check()),
+        ];
+    }
+
+    public function defineColumns(): array
+    {
+        return [
+            TextColumn::make('name')->hidden(),
+        ];
+    }
+}

--- a/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithConditionallyHiddenStuff.php
+++ b/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithConditionallyHiddenStuff.php
@@ -13,6 +13,9 @@ use Illuminate\Support\Collection;
 
 class BasicProductsTableWithConditionallyHiddenStuff extends Table
 {
+    public static ?string $name = null;
+    public static ?array $names = [];
+
     protected string $model = Product::class;
 
     public function defineRefiners(): array
@@ -26,8 +29,12 @@ class BasicProductsTableWithConditionallyHiddenStuff extends Table
     public function defineActions(): array
     {
         return [
-            BulkAction::make('say_our_names')->action(fn (Collection $records) => $records->each(fn (Product $record) => $record->name))->hidden(!auth()->check()),
-            InlineAction::make('say_my_name')->action(fn (Product $record) => $record->name)->hidden(!auth()->check()),
+            BulkAction::make('say_our_names')
+                ->action(fn (Collection $records) => $records->each(fn (Product $record) => self::$names[] = $record->name))
+                ->hidden(!auth()->check()),
+            InlineAction::make('say_my_name')
+                ->action(fn (Product $record) => self::$name = $record->name)
+                ->hidden(!auth()->check()),
         ];
     }
 

--- a/packages/laravel/tests/Laravel/Tables/TableTest.php
+++ b/packages/laravel/tests/Laravel/Tables/TableTest.php
@@ -71,7 +71,7 @@ it('can execute a conditionally hidden inline actions', function () {
         'recordId' => $product->id,
     ])->assertRedirect();
 
-    expect(BasicProductsTableWithActions::$name)->toBe($product->name);
+    expect(BasicProductsTableWithConditionallyHiddenStuff::$name)->toBe($product->name);
 });
 
 it('can execute bulk actions with all records', function () {

--- a/packages/laravel/tests/Laravel/Tables/TableTest.php
+++ b/packages/laravel/tests/Laravel/Tables/TableTest.php
@@ -5,6 +5,7 @@ use Hybridly\Tests\Fixtures\Database\ProductFactory;
 use Hybridly\Tests\Fixtures\Vendor;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTable;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithActions;
+use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithConditionallyHiddenStuff;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithData;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithHiddenStuff;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicScopedProductsTable;
@@ -49,6 +50,24 @@ it('can execute inline actions', function () {
         'type' => 'action:inline',
         'action' => 'say_my_name',
         'tableId' => BasicProductsTableWithActions::class,
+        'recordId' => $product->id,
+    ])->assertRedirect();
+
+    expect(BasicProductsTableWithActions::$name)->toBe($product->name);
+});
+
+it('can execute a conditionally hidden inline actions', function () {
+    Table::encodeIdUsing(static fn () => BasicProductsTableWithConditionallyHiddenStuff::class);
+    Table::decodeIdUsing(static fn () => BasicProductsTableWithConditionallyHiddenStuff::class);
+
+    $product = ProductFactory::createImmutable();
+
+    $this->withoutExceptionHandling();
+
+    post(config('hybridly.tables.actions_endpoint'), [
+        'type' => 'action:inline',
+        'action' => 'say_my_name',
+        'tableId' => BasicProductsTableWithConditionallyHiddenStuff::class,
         'recordId' => $product->id,
     ])->assertRedirect();
 


### PR DESCRIPTION
This PR creates a failing test for an issue I've discovered. I'm happy to submit a PR for the fix if you could point me in the direction you'd like me to take.

## Issue

If you have a conditionally hidden action and the condition depends on part of the request (ie: in my case I need to hide the action by default and then show the action when a specific refinement is applied), then you will receive a 500 when trying to invoke that action.

For example:

- I use the default `TrashedFilter` to show active vs trashed records
- I have an action to restore a record, but this action is only visible when the `TrashedFilter` is being applied
- When trying to invoke the action, I receive a 500 because the following chunk of code from `HasActions` cannot find the specified action since it is hidden by default:

```php
    public function getActions(): Collection
    {
        return $this->cachedActions ??= collect($this->defineActions())
            ->filter(static fn (BaseAction $action): bool => !$action->isHidden());
    }

    public function getInlineActions(): Collection
    {
        return $this->getActions()->filter(static fn (BaseAction $action): bool => $action instanceof InlineAction);
    }

    public function getBulkActions(): Collection
    {
        return $this->getActions()->filter(static fn (BaseAction $action): bool => $action instanceof BulkAction);
    }
```

## Fixing the issue

My initial thought would be to create a `getAllActions()` method in `HasActions` and call that within `getInlineActions` and `getBulkActions`. One issue with that approach is it would essentially remove any sort of authorization enforcement on actions. You may want to consider a new method on actions for authorization (may be a good idea anyways).