### PR TITLE
feat(tables): support custom model resolution logic for inline actions

### DIFF
--- a/packages/laravel/src/Tables/Actions/Concerns/ResolvesModel.php
+++ b/packages/laravel/src/Tables/Actions/Concerns/ResolvesModel.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Hybridly\Tables\Actions\Concerns;
+
+use Hybridly\Tables\Actions\DataTransferObjects\InlineActionData;
+use Illuminate\Database\Eloquent\Model;
+
+trait ResolvesModel
+{
+    protected \Closure $resolveModelUsing;
+
+    /**
+     * Defines how the model should be resolved. The first argument given to the callback is the model class, and the second the action data.
+     */
+    public function resolveModelUsing(\Closure $resolver): static
+    {
+        $this->resolveModelUsing = $resolver;
+
+        return $this;
+    }
+
+    public function resolveModel(string $modelClass, InlineActionData $data): Model
+    {
+        $resolver = $this->resolveModelUsing ?? fn (string $modelClass, InlineActionData $data) => $modelClass::findOrFail($data->recordId);
+
+        return \call_user_func($resolver, $modelClass, $data);
+    }
+}

--- a/packages/laravel/src/Tables/Actions/Http/InvokedActionController.php
+++ b/packages/laravel/src/Tables/Actions/Http/InvokedActionController.php
@@ -70,8 +70,8 @@ final class InvokedActionController
          */
         [$table, $action] = $this->resolveAction($data);
 
-        $model = $table->getModelClass();
-        $record = $model::findOrFail($data->recordId);
+        $modelClass = $table->getModelClass();
+        $record = $action->resolveModel($modelClass, $data);
         $result = $table->evaluate(
             value: $action->getAction(),
             named: [

--- a/packages/laravel/src/Tables/Actions/InlineAction.php
+++ b/packages/laravel/src/Tables/Actions/InlineAction.php
@@ -2,6 +2,25 @@
 
 namespace Hybridly\Tables\Actions;
 
+use Closure;
+use Hybridly\Tables\Actions\DataTransferObjects\InlineActionData;
+use Illuminate\Database\Eloquent\Model;
+
 class InlineAction extends BaseAction
 {
+    protected Closure $modelResolver;
+
+    public function resolveModelUsing(Closure $resolver): static
+    {
+        $this->modelResolver = $resolver;
+
+        return $this;
+    }
+
+    public function resolveModel(string $modelClass, InlineActionData $data): Model
+    {
+        $resolver = $this->modelResolver ?? fn (string $modelClass, InlineActionData $data) => $modelClass::findOrFail($data->recordId);
+
+        return \call_user_func($resolver, $modelClass, $data);
+    }
 }

--- a/packages/laravel/src/Tables/Actions/InlineAction.php
+++ b/packages/laravel/src/Tables/Actions/InlineAction.php
@@ -2,25 +2,9 @@
 
 namespace Hybridly\Tables\Actions;
 
-use Closure;
-use Hybridly\Tables\Actions\DataTransferObjects\InlineActionData;
-use Illuminate\Database\Eloquent\Model;
+use Hybridly\Tables\Actions\Concerns\ResolvesModel;
 
 class InlineAction extends BaseAction
 {
-    protected Closure $modelResolver;
-
-    public function resolveModelUsing(Closure $resolver): static
-    {
-        $this->modelResolver = $resolver;
-
-        return $this;
-    }
-
-    public function resolveModel(string $modelClass, InlineActionData $data): Model
-    {
-        $resolver = $this->modelResolver ?? fn (string $modelClass, InlineActionData $data) => $modelClass::findOrFail($data->recordId);
-
-        return \call_user_func($resolver, $modelClass, $data);
-    }
+    use ResolvesModel;
 }

--- a/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithSoftDeleteAction.php
+++ b/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithSoftDeleteAction.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Hybridly\Tests\Laravel\Tables\Fixtures;
+
+use Hybridly\Refining\Filters\Filter;
+use Hybridly\Refining\Sorts\Sort;
+use Hybridly\Tables\Actions\InlineAction;
+use Hybridly\Tables\Columns\TextColumn;
+use Hybridly\Tables\Table;
+use Hybridly\Tests\Fixtures\Database\Product;
+
+class BasicProductsTableWithSoftDeleteAction extends Table
+{
+    public static ?string $name = null;
+    public static ?array $names = [];
+
+    protected string $model = Product::class;
+
+    public function defineRefiners(): array
+    {
+        return [
+            Sort::make('name'),
+            Filter::make('name'),
+        ];
+    }
+
+    public function defineActions(): array
+    {
+        return [
+            InlineAction::make('say_my_name')->action(fn (Product $record) => self::$name = $record->name)->resolveModelUsing(fn (string $modelClass, $data) => $modelClass::withTrashed()->findOrFail($data->recordId)),
+        ];
+    }
+
+    public function defineColumns(): array
+    {
+        return [
+            TextColumn::make('name'),
+        ];
+    }
+}

--- a/packages/laravel/tests/Laravel/Tables/TableTest.php
+++ b/packages/laravel/tests/Laravel/Tables/TableTest.php
@@ -8,6 +8,7 @@ use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithActions;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithConditionallyHiddenStuff;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithData;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithHiddenStuff;
+use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithSoftDeleteAction;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicScopedProductsTable;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicTableWithConstructor;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicTableWithDependencyInjection;
@@ -54,6 +55,23 @@ it('can execute inline actions', function () {
     ])->assertRedirect();
 
     expect(BasicProductsTableWithActions::$name)->toBe($product->name);
+});
+
+it('can execute inline action for soft deleted records', function () {
+    Table::encodeIdUsing(static fn () => BasicProductsTableWithSoftDeleteAction::class);
+    Table::decodeIdUsing(static fn () => BasicProductsTableWithSoftDeleteAction::class);
+
+    $product = ProductFactory::createImmutable();
+    $product->delete();
+
+    post(config('hybridly.tables.actions_endpoint'), [
+        'type' => 'action:inline',
+        'action' => 'say_my_name',
+        'tableId' => BasicProductsTableWithSoftDeleteAction::class,
+        'recordId' => $product->id,
+    ])->assertRedirect();
+
+    expect(BasicProductsTableWithSoftDeleteAction::$name)->toBe($product->name);
 });
 
 it('can execute a conditionally hidden inline actions', function () {


### PR DESCRIPTION
Similar to the case described here: https://github.com/hybridly/hybridly/pull/112

Same as the other PR, I am happy to update this PR with a fix if you can point me in the direction you want it fixed.

---

Use case:

We allow users to view their soft deleted records. From this page, they have the ability to restore these records.

## Issue

The model look up logic in `InvokedActionController` can't handle soft deleted records. The issue is on this line:

```
$model = $table->getModelClass();
$record = $model::findOrFail($data->recordId);
```

## Solving the issue

Ideally there would be a way to define how the action's model is queried for/found. This would allow us to apply a scope during the look up.