### PR TITLE
fix(forms): update `isDirty` using `initial` fields instead of `loaded`

### DIFF
--- a/packages/vue/src/composables/form.ts
+++ b/packages/vue/src/composables/form.ts
@@ -232,7 +232,7 @@ export function useForm<
 	}
 
 	watch([fields, processing, errors], () => {
-		isDirty.value = !isEqual(toRaw(loaded), toRaw(fields))
+		isDirty.value = !isEqual(toRaw(initial), toRaw(fields))
 
 		if (shouldRemember) {
 			router.history.remember(historyKey, {


### PR DESCRIPTION
I am not sure if this change is "correct". This change would make `loaded` now unused within the codebase. So I assume there must have been a reason to add `loaded` instead of changing `initial` to be `historyData.fields ?? options.fields`.