### PR TITLE
fix(tables): instanciate data instances using models instead of their serialized representation

### DIFF
--- a/docs/guide/tables.md
+++ b/docs/guide/tables.md
@@ -440,6 +440,28 @@ const $props = defineProps<{
 }>()
 ```
 
+You also have the ability to customize the `Data` record's resolution logic. For example, if you need to exclude authorizations (on the root record or nested records) when rendering a table:
+
+```php
+use App\Models\User;
+use App\Data\UserData;
+use Hybridly\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\LaravelData\Data;
+
+
+final class UsersTable extends Table
+{
+    protected string $model = User::class;
+		protected string $data = UserData::class;
+
+    protected function resolveDataRecord(Model $model): Data
+    {
+        return $this->data::from($model)->exclude('authorization', 'nested.authorization');
+    }
+}
+```
+
 ### Hooking into the paginator
 
 In certain scenarios, you may want to hook into the paginator to manually transform the records. 

--- a/packages/laravel/src/Tables/Concerns/RefinesAndPaginateRecords.php
+++ b/packages/laravel/src/Tables/Concerns/RefinesAndPaginateRecords.php
@@ -145,10 +145,15 @@ trait RefinesAndPaginateRecords
     protected function getRecordFromModel(Model $model): array|Data
     {
         if (isset($this->data) && is_a($this->data, Data::class, allow_string: true)) {
-            return $this->data::from($model)->toArray();
+            return $this->resolveDataRecord($model)->toArray();
         }
 
         return $model->toArray();
+    }
+
+    protected function resolveDataRecord(Model $model): Data
+    {
+        return $this->data::from($model);
     }
 
     private function getPaginatedRecords(): array

--- a/packages/laravel/src/Tables/Concerns/RefinesAndPaginateRecords.php
+++ b/packages/laravel/src/Tables/Concerns/RefinesAndPaginateRecords.php
@@ -168,8 +168,9 @@ trait RefinesAndPaginateRecords
         $modelClass = $this->getModelClass();
         $includeOriginalRecordId = Configuration::get()->tables->enableActions && $columnsWithTransforms->contains(static fn (BaseColumn $column) => $column->getName() === $keyName);
         $columnNames = $columns->map(static fn (BaseColumn $column) => $column->getName());
+        $columnsToInclude = [...$columnNames->toArray(), $keyName, '__hybridId', 'authorization'];
 
-        return $paginatedRecords->through(function (Model $model) use ($includeOriginalRecordId, $columnsWithTransforms, $modelClass, $columnNames, $keyName) {
+        return $paginatedRecords->through(function (Model $model) use ($includeOriginalRecordId, $columnsWithTransforms, $modelClass, $columnNames, $keyName, $columnsToInclude) {
             $record = $this->getRecordFromModel($model);
 
             // If actions are enabled but the record's key is not included in the
@@ -194,7 +195,7 @@ trait RefinesAndPaginateRecords
                         ),
                     ]),
                 ],
-                callback: fn (string $key) => \in_array($key, [...$columnNames->toArray(), $keyName], true),
+                callback: fn (string $key) => \in_array($key, $columnsToInclude, true),
                 mode: \ARRAY_FILTER_USE_KEY,
             );
         });

--- a/packages/laravel/tests/.pest/snapshots/Laravel/Tables/TableTest/it_can_transform_records_using_Laravel_Data.snap
+++ b/packages/laravel/tests/.pest/snapshots/Laravel/Tables/TableTest/it_can_transform_records_using_Laravel_Data.snap
@@ -12,7 +12,11 @@
     },
     "records": [
         {
-            "name": "AirPods"
+            "name": "AirPods",
+            "authorization": {
+                "returns-true": false,
+                "returns-false": false
+            }
         }
     ],
     "paginator": {
@@ -39,10 +43,8 @@
             "from": 1,
             "last_page": 1,
             "last_page_url": "http:\/\/localhost?page=1",
-            "next_page_url": null,
             "path": "http:\/\/localhost",
             "per_page": 10,
-            "prev_page_url": null,
             "to": 1,
             "total": 1
         }

--- a/packages/laravel/tests/.pest/snapshots/Laravel/Tables/TableTest/it_includes_authorization_on_records_when_using_Laravel_Data.snap
+++ b/packages/laravel/tests/.pest/snapshots/Laravel/Tables/TableTest/it_includes_authorization_on_records_when_using_Laravel_Data.snap
@@ -15,7 +15,7 @@
             "name": "AirPods",
             "created_at": "2021-01-01T00:00:00+00:00",
             "authorization": {
-                "returns-true": false,
+                "returns-true": true,
                 "returns-false": false
             }
         }

--- a/packages/laravel/tests/Fixtures/Database/User.php
+++ b/packages/laravel/tests/Fixtures/Database/User.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Hybridly\Tests\Fixtures\Database;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+final class User extends Authenticatable
+{
+}

--- a/packages/laravel/tests/Fixtures/Database/UserFactory.php
+++ b/packages/laravel/tests/Fixtures/Database/UserFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Hybridly\Tests\Fixtures\Database;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class UserFactory extends Factory
+{
+    protected $model = User::class;
+
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name(),
+        ];
+    }
+}

--- a/packages/laravel/tests/Fixtures/Database/migrations/create_users_table.php
+++ b/packages/laravel/tests/Fixtures/Database/migrations/create_users_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+};

--- a/packages/laravel/tests/Fixtures/Providers/TestingServiceProvider.php
+++ b/packages/laravel/tests/Fixtures/Providers/TestingServiceProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Hybridly\Tests\Fixtures\Providers;
+
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
+
+final class TestingServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Gate::define('returns-true', fn () => true);
+        Gate::define('returns-false', fn () => false);
+    }
+}

--- a/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithData.php
+++ b/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithData.php
@@ -5,26 +5,16 @@ namespace Hybridly\Tests\Laravel\Tables\Fixtures;
 use Hybridly\Tables\Columns\TextColumn;
 use Hybridly\Tables\Table;
 use Hybridly\Tests\Fixtures\Database\Product;
-use Illuminate\Contracts\Pagination\CursorPaginator;
-use Illuminate\Contracts\Pagination\Paginator;
-use Spatie\LaravelData\Contracts\DataCollectable;
 
 class BasicProductsTableWithData extends Table
 {
     protected string $model = Product::class;
+    protected string $data = ProductNameData::class;
 
     public function defineColumns(): array
     {
         return [
             TextColumn::make('name'),
         ];
-    }
-
-    public function transformRecords(Paginator|CursorPaginator $paginator): DataCollectable
-    {
-        /** @var DataCollectable */
-        $records = ProductNameData::collection($paginator);
-
-        return $records;
     }
 }

--- a/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithData.php
+++ b/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithData.php
@@ -15,6 +15,7 @@ class BasicProductsTableWithData extends Table
     {
         return [
             TextColumn::make('name'),
+            TextColumn::make('created_at'),
         ];
     }
 }

--- a/packages/laravel/tests/Laravel/Tables/Fixtures/ProductNameData.php
+++ b/packages/laravel/tests/Laravel/Tables/Fixtures/ProductNameData.php
@@ -2,10 +2,15 @@
 
 namespace Hybridly\Tests\Laravel\Tables\Fixtures;
 
-use Spatie\LaravelData\Data;
+use Hybridly\Support\Data\DataResource;
 
-class ProductNameData extends Data
+class ProductNameData extends DataResource
 {
+    protected static array $authorizations = [
+        'returns-true',
+        'returns-false',
+    ];
+
     public function __construct(
         public readonly string $name,
     ) {

--- a/packages/laravel/tests/Laravel/Tables/Fixtures/ProductNameData.php
+++ b/packages/laravel/tests/Laravel/Tables/Fixtures/ProductNameData.php
@@ -2,6 +2,7 @@
 
 namespace Hybridly\Tests\Laravel\Tables\Fixtures;
 
+use Carbon\CarbonInterface;
 use Hybridly\Support\Data\DataResource;
 
 class ProductNameData extends DataResource
@@ -13,6 +14,7 @@ class ProductNameData extends DataResource
 
     public function __construct(
         public readonly string $name,
+        public readonly CarbonInterface $created_at,
     ) {
     }
 }

--- a/packages/laravel/tests/Laravel/Tables/TableTest.php
+++ b/packages/laravel/tests/Laravel/Tables/TableTest.php
@@ -42,16 +42,7 @@ it('includes authorization on records when using Laravel Data', function () {
     Auth::login(UserFactory::new()->create());
     ProductFactory::createImmutable();
 
-    $table = BasicProductsTableWithData::make();
-    expect($table->getRecords())->toBe([
-        [
-            'name' => 'AirPods',
-            'authorization' => [
-                'returns-true' => true,
-                'returns-false' => false,
-            ],
-        ],
-    ]);
+    expect(BasicProductsTableWithData::make())->toMatchSnapshot();
 });
 
 it('hides hidden refinements, columns and actions in serialization', function () {

--- a/packages/laravel/tests/Laravel/Tables/TableTest.php
+++ b/packages/laravel/tests/Laravel/Tables/TableTest.php
@@ -2,6 +2,7 @@
 
 use Hybridly\Tables\Table;
 use Hybridly\Tests\Fixtures\Database\ProductFactory;
+use Hybridly\Tests\Fixtures\Database\UserFactory;
 use Hybridly\Tests\Fixtures\Vendor;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTable;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithActions;
@@ -13,6 +14,7 @@ use Hybridly\Tests\Laravel\Tables\Fixtures\BasicScopedProductsTable;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicTableWithConstructor;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicTableWithDependencyInjection;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicTableWithDependencyInjectionAndArguments;
+use Illuminate\Support\Facades\Auth;
 
 use function Pest\Laravel\post;
 
@@ -34,6 +36,22 @@ it('serializes a basic scoped table', function () {
 it('can transform records using Laravel Data', function () {
     ProductFactory::createImmutable();
     expect(BasicProductsTableWithData::make())->toMatchSnapshot();
+});
+
+it('includes authorization on records when using Laravel Data', function () {
+    Auth::login(UserFactory::new()->create());
+    ProductFactory::createImmutable();
+
+    $table = BasicProductsTableWithData::make();
+    expect($table->getRecords())->toBe([
+        [
+            'name' => 'AirPods',
+            'authorization' => [
+                'returns-true' => true,
+                'returns-false' => false,
+            ],
+        ],
+    ]);
 });
 
 it('hides hidden refinements, columns and actions in serialization', function () {

--- a/packages/laravel/tests/TestCase.php
+++ b/packages/laravel/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Hybridly\Tests;
 
 use Hybridly\HybridlyServiceProvider;
+use Hybridly\Tests\Fixtures\Providers\TestingServiceProvider;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase as Orchestra;
@@ -23,6 +24,7 @@ class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         return [
+            TestingServiceProvider::class,
             HybridlyServiceProvider::class,
             LaravelDataServiceProvider::class,
             RayServiceProvider::class,

--- a/packages/laravel/tests/TestCase.php
+++ b/packages/laravel/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Hybridly\Tests;
 
+use Carbon\Carbon;
 use Hybridly\HybridlyServiceProvider;
 use Hybridly\Tests\Fixtures\Providers\TestingServiceProvider;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
@@ -18,6 +19,7 @@ class TestCase extends Orchestra
     {
         parent::setUp();
 
+        Carbon::setTestNow(now());
         View::addLocation(__DIR__ . '/stubs');
     }
 


### PR DESCRIPTION
This PR fixes two issues that were caused by the same source:

1. If you were using a casted property in a `Data` class, such as a `CarbonInterface`, an exception would be thrown when trying to render the `Data` class in a `Table`.
2. The `authorization` array on all Table records was always empty.

Both of these problems happened because the `Data` class was being created with a serialized JSON array of the model instead of the model itself.

The casted properties did not work because the casting of the model to JSON would transform the casted property to its primitive value (string), therefore the type would no longer match what was defined in the `Data` class.

The `authorization` array was always empty because the `Data` class was not being given a model as its source, therefore it could not call the authorization gates correctly.