### PR TITLE
feat(ide): add autocompletion for route names on `->base()` method

### DIFF
--- a/packages/vite/src/typegen/index.ts
+++ b/packages/vite/src/typegen/index.ts
@@ -78,6 +78,16 @@ export function generateLaravelIdeaHelper(config: DynamicConfiguration) {
 					},
 				],
 			},
+			{
+				complete: 'routeName',
+				condition: [
+					{
+						classFqn: ['Hybridly\\Hybridly'],
+						methodNames: ['base'],
+						parameters: [1],
+					},
+				],
+			},
 		],
 	}
 


### PR DESCRIPTION
This adds autocompletion for the `hybridly()->base()` method :) 