### PR TITLE
feat(architecture): use kebab for view identifiers

### DIFF
--- a/packages/laravel/src/Support/VueViewFinder.php
+++ b/packages/laravel/src/Support/VueViewFinder.php
@@ -243,13 +243,17 @@ final class VueViewFinder
      */
     protected function getIdentifier(string $path, string $baseDirectory, string $namespace): string
     {
-        return str($path)
-            ->after($baseDirectory)
-            ->ltrim('/\\')
-            ->replace(['/', '\\'], '.')
-            ->replace($this->extensions, '')
+        return str(
+            str($path)
+                ->after($baseDirectory)
+                ->ltrim('/\\')
+                ->replace(['/', '\\'], '.')
+                ->replace($this->extensions, '')
+                ->explode('.')
+                ->map(fn (string $str) => str($str)->kebab())
+                ->join('.'),
+        )
             ->when($namespace !== 'default')
-            ->prepend("{$namespace}::")
-            ->lower();
+            ->prepend("{$namespace}::");
     }
 }

--- a/packages/laravel/src/View/View.php
+++ b/packages/laravel/src/View/View.php
@@ -11,6 +11,11 @@ class View implements Arrayable
         public array $properties,
         public array $deferred = [],
     ) {
+        if (preg_match('/[A-Z]/', $this->component)) {
+            $expected = str($this->component)->explode('.')->map(fn (string $s) => str($s)->kebab())->join('.');
+            trigger_deprecation('hybridly/laravel', '0.7', `Passing component names with uppercase to hybridly is deprecated, you should use kebab case instead (Received: $this->component, expected: $expected)`);
+            $this->component = $expected;
+        }
     }
 
     public function toArray()


### PR DESCRIPTION
In 0.7 the components are now in lowercase

https://github.com/hybridly/hybridly/commit/fa34630e194b15a240799e26d0371e0b6b306fe3

Appart from being quite the breaking change, this now makes hard to read component names

Eg before

`Auth.ForgotPassword`
`AppPagination`

Now

`auth.forgotpassword`
`apppagination`

Proposed in PR

`auth.forgot-password`
`app-pagination`

I also put backward compat in place to ease the transition