### PR TITLE
cd(provenance): use `package.json` setting instead

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,9 @@ jobs:
         run: pnpm run build
 
       - name: Publish to NPM
-        run: pnpm -r publish --access public --no-git-checks
+        run: pnpm -r publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-          NPM_CONFIG_PROVENANCE: true
 
       - run: npx conventional-github-releaser -p angular
         continue-on-error: true

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,10 @@
   "bugs": {
     "url": "https://github.com/hybridly/hybridly/issues"
   },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "sideEffects": false,
   "files": [
     "dist",

--- a/packages/hybridly/package.json
+++ b/packages/hybridly/package.json
@@ -18,6 +18,10 @@
   "bugs": {
     "url": "https://github.com/hybridly/hybridly/issues"
   },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "sideEffects": false,
   "files": [
     "dist",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,6 +18,10 @@
   "bugs": {
     "url": "https://github.com/hybridly/hybridly/issues"
   },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "sideEffects": false,
   "files": [
     "dist",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -21,6 +21,10 @@
   "bugs": {
     "url": "https://github.com/hybridly/hybridly/issues"
   },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "sideEffects": false,
   "files": [
     "dist",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -20,6 +20,10 @@
   },
   "funding": "https://github.com/sponsors/innocenzi",
   "author": "Enzo Innocenzi <enzo@innocenzi.dev>",
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "sideEffects": false,
   "type": "module",
   "files": [


### PR DESCRIPTION
PNPM sadly does not seem to properly apply the ENV variable to the packages.

So we added the publish config to every package.json. This should actually work now, see [0] for an example.

Additionally, this removes the env var and the public flag, because this one was also moved to the config.

[0]: https://github.com/clickbar/eslint-config/blob/d88e413c610e478a48ccd52f5a4a35cfa4865760/packages/vue/package.json