### PR TITLE
fix(use-property): handle null values

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -47,7 +47,7 @@
     "vue": "^3.2.45"
   },
   "dependencies": {
-    "@clickbar/dot-diver": "^1.0.4",
+    "@clickbar/dot-diver": "^1.0.5",
     "@hybridly/core": "workspace:*",
     "@hybridly/utils": "workspace:*",
     "@vue/devtools-api": "^6.6.1",

--- a/packages/vue/src/composables/property.ts
+++ b/packages/vue/src/composables/property.ts
@@ -20,14 +20,8 @@ export function useProperty<
 	path: [Override] extends [never]
 		? P
 		: string,
-): ComputedRef<ReturnType | undefined> {
-	return computed(() => {
-		try {
-			return getByPath(state.context.value?.view.properties as GlobalHybridlyProperties, path) as ReturnType
-		} catch {
-			return undefined
-		}
-	})
+): ComputedRef<ReturnType> {
+	return computed(() => getByPath(state.context.value?.view.properties as GlobalHybridlyProperties, path) as ReturnType)
 }
 
 /**

--- a/packages/vue/src/composables/property.ts
+++ b/packages/vue/src/composables/property.ts
@@ -20,8 +20,14 @@ export function useProperty<
 	path: [Override] extends [never]
 		? P
 		: string,
-): ComputedRef<ReturnType> {
-	return computed(() => getByPath(state.context.value?.view.properties as GlobalHybridlyProperties, path) as ReturnType)
+): ComputedRef<ReturnType | undefined> {
+	return computed(() => {
+		try {
+			return getByPath(state.context.value?.view.properties as GlobalHybridlyProperties, path) as ReturnType
+		} catch {
+			return undefined
+		}
+	})
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
   packages/vue:
     dependencies:
       '@clickbar/dot-diver':
-        specifier: ^1.0.4
-        version: 1.0.4
+        specifier: ^1.0.5
+        version: 1.0.5
       '@hybridly/core':
         specifier: workspace:*
         version: link:../core
@@ -916,8 +916,8 @@ packages:
       statuses: 2.0.1
     dev: true
 
-  /@clickbar/dot-diver@1.0.4:
-    resolution: {integrity: sha512-93D4DWoFdsWobcxGgOgisRbvIsGf0slmuT/mwXu4REisDe4aIyIgSsjuDqPATEbNph+ugTpJmAAlDChDagLHgg==}
+  /@clickbar/dot-diver@1.0.5:
+    resolution: {integrity: sha512-3vZhf4mWl51N0Cj2dD+ieXttPKqfOISDJcKsf1NX9J9ZK7+oM/mLuWxt9IObmxuVcInUE1CdusXRxnnt9jI62g==}
     dev: false
 
   /@docsearch/css@3.5.2:


### PR DESCRIPTION
When using optional data with spatie then that value is given as null in hybridly (and not undefined)

```
props: {
  user: null
}
```

When using `useProperty('user.id')` in this case, getByPath throws an exception that it can't convert `null` to `object`

Instead of erroring we should just return undefined

This error does not happen if user was undefined
```
props: {
  user: undefined
}
```