### PR TITLE
ci: update actions & nodejs version

### DIFF
--- a/.github/workflows/monorepo-split.yml
+++ b/.github/workflows/monorepo-split.yml
@@ -15,7 +15,7 @@ jobs:
           - laravel
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: previous-tag
         uses: "WyriHaximus/github-action-get-previous-tag@master"
       - name: Split of ${{ matrix.package }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,17 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.4
-        with:
-          version: 8.6.3
+        uses: pnpm/action-setup@v3
 
-      - name: Use Node.js v16
-        uses: actions/setup-node@v2
+      - name: Use Node.js v20
+        uses: actions/setup-node@v4
         with:
-          node-version: v16
+          node-version: v20
           registry-url: https://registry.npmjs.org/
           cache: "pnpm"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x]
+        node-version: ["18.x", "20.x"]
         os: [ubuntu-latest]
         php: [8.2, 8.3]
-        laravel: ['10.*', '11.*']
+        laravel: ["10.*", "11.*"]
         include:
           - laravel: 10.*
             testbench: 8.*
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.4
+        uses: pnpm/action-setup@v3
         with:
           version: latest
 
@@ -50,7 +50,7 @@ jobs:
           coverage: none
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["18.x", "20.x"]
+        node-version: ["20.x"]
         os: [ubuntu-latest]
         php: [8.2, 8.3]
         laravel: ["10.*", "11.*"]


### PR DESCRIPTION
This updates the GitHub action versions to their latest version. None of these had any breaking changes and were mostly adjusted to run on the latest node version.

We also fix the provenance with upgrading to node v20 in the `release` workflow. Since node v16 did contain a too old npm version it just ignored the unknown provenance setting and did not work. This is fixed now.

Additionally the explicit pnpm version in the `release` workflow was dismissed, since it will automatically choose the version as specified in the root package.json. This way we do not need to define this at multiple places and keep it in sync.

For the `tests.yml` workflow, we also added node v20 to the test matrix to cover the newest LTS. Note that v18 is kept, because it still receives security patches and is useable.