### PR TITLE
feat(authorization): support tables and custom creation methods

### DIFF
--- a/packages/laravel/src/Support/Data/AuthorizationArrayResolver.php
+++ b/packages/laravel/src/Support/Data/AuthorizationArrayResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Hybridly\Support\Data;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
+
+final class AuthorizationArrayResolver
+{
+    public function resolve(Model $model, string $dataClass): array
+    {
+        return collect($dataClass::getAuthorizations())
+            ->mapWithKeys(function (array|string $value, int|string $key) use ($model) {
+                $action = \is_int($key) ? $value : $key;
+                $policy = \is_array($value) ? $value : [$value, $action];
+
+                try {
+                    if (!\is_int($key)) {
+                        return [$action => Gate::allows($policy[1], [$policy[0], $model])];
+                    }
+
+                    return [$action => Gate::allows($action, $model)];
+                } catch (\ArgumentCountError $previous) {
+                    throw new \ArgumentCountError(
+                        previous: $previous,
+                        message: sprintf(
+                            'Could not allow action `%s` on model `%s`. %s',
+                            $action,
+                            \is_string($model) ? $model : $model::class,
+                            $previous->getMessage(),
+                        ),
+                    );
+                }
+            })
+            ->toArray();
+    }
+}

--- a/packages/laravel/src/Support/Data/DataResource.php
+++ b/packages/laravel/src/Support/Data/DataResource.php
@@ -2,6 +2,7 @@
 
 namespace Hybridly\Support\Data;
 
+use Illuminate\Database\Eloquent\Model;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataPipeline;
 use Spatie\LaravelData\Lazy;
@@ -23,5 +24,10 @@ abstract class DataResource extends Data implements DataResourceContract
     public function withoutAuthorizations(): static
     {
         return $this->excludePermanently('authorization');
+    }
+
+    protected static function resolveAuthorizationArray(Model $model): array
+    {
+        return resolve(AuthorizationArrayResolver::class)->resolve($model, static::class);
     }
 }

--- a/packages/laravel/src/Support/Data/ResolveAuthorizationsPipe.php
+++ b/packages/laravel/src/Support/Data/ResolveAuthorizationsPipe.php
@@ -3,7 +3,6 @@
 namespace Hybridly\Support\Data;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Gate;
 use Spatie\LaravelData\DataPipes\DataPipe;
 use Spatie\LaravelData\Lazy;
 use Spatie\LaravelData\Support\Creation\CreationContext;
@@ -11,6 +10,11 @@ use Spatie\LaravelData\Support\DataClass;
 
 final class ResolveAuthorizationsPipe implements DataPipe
 {
+    public function __construct(
+        private readonly AuthorizationArrayResolver $resolver,
+    ) {
+    }
+
     public function handle(mixed $payload, DataClass $class, array $properties, CreationContext $creationContext): array
     {
         if (!$payload instanceof Model) {
@@ -23,35 +27,7 @@ final class ResolveAuthorizationsPipe implements DataPipe
 
         return [
             ...$properties,
-            'authorization' => Lazy::create(fn () => $this->getAuthorizationArray($payload, $dataClass))->defaultIncluded(),
+            'authorization' => Lazy::create(fn () => $this->resolver->resolve($payload, $dataClass))->defaultIncluded(),
         ];
-    }
-
-    private function getAuthorizationArray(Model $model, string $dataClass): array
-    {
-        return collect($dataClass::getAuthorizations())
-            ->mapWithKeys(function (array|string $value, int|string $key) use ($model) {
-                $action = \is_int($key) ? $value : $key;
-                $policy = \is_array($value) ? $value : [$value, $action];
-
-                try {
-                    if (!\is_int($key)) {
-                        return [$action => Gate::allows($policy[1], [$policy[0], $model])];
-                    }
-
-                    return [$action => Gate::allows($action, $model)];
-                } catch (\ArgumentCountError $previous) {
-                    throw new \ArgumentCountError(
-                        previous: $previous,
-                        message: sprintf(
-                            'Could not allow action `%s` on model `%s`. %s',
-                            $action,
-                            \is_string($model) ? $model : $model::class,
-                            $previous->getMessage(),
-                        ),
-                    );
-                }
-            })
-            ->toArray();
     }
 }

--- a/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithDataUsingFromModel.php
+++ b/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithDataUsingFromModel.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Hybridly\Tests\Laravel\Tables\Fixtures;
+
+use Hybridly\Tables\Columns\TextColumn;
+use Hybridly\Tables\Table;
+use Hybridly\Tests\Fixtures\Database\Product;
+
+class BasicProductsTableWithDataUsingFromModel extends Table
+{
+    protected string $model = Product::class;
+    protected string $data = ProductNameDataUsingFromModel::class;
+
+    public function defineColumns(): array
+    {
+        return [
+            TextColumn::make('name'),
+            TextColumn::make('created_at'),
+        ];
+    }
+}

--- a/packages/laravel/tests/Laravel/Tables/Fixtures/ProductNameDataUsingFromModel.php
+++ b/packages/laravel/tests/Laravel/Tables/Fixtures/ProductNameDataUsingFromModel.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Hybridly\Tests\Laravel\Tables\Fixtures;
+
+use Carbon\CarbonInterface;
+use Hybridly\Support\Data\DataResource;
+use Hybridly\Tests\Fixtures\Database\Product;
+
+class ProductNameDataUsingFromModel extends DataResource
+{
+    protected static array $authorizations = [
+        'returns-true',
+        'returns-false',
+    ];
+
+    public function __construct(
+        public readonly string $name,
+        public readonly CarbonInterface $created_at,
+    ) {
+    }
+
+    public static function fromModel(Product $product): static
+    {
+        return new static(
+            name: $product->name,
+            created_at: $product->created_at,
+        );
+    }
+}

--- a/packages/laravel/tests/Laravel/Tables/TableTest.php
+++ b/packages/laravel/tests/Laravel/Tables/TableTest.php
@@ -8,6 +8,7 @@ use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTable;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithActions;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithConditionallyHiddenStuff;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithData;
+use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithDataUsingFromModel;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithHiddenStuff;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicProductsTableWithSoftDeleteAction;
 use Hybridly\Tests\Laravel\Tables\Fixtures\BasicScopedProductsTable;
@@ -42,7 +43,17 @@ it('includes authorization on records when using Laravel Data', function () {
     Auth::login(UserFactory::new()->create());
     ProductFactory::createImmutable();
 
-    expect(BasicProductsTableWithData::make())->toMatchSnapshot();
+    $result = BasicProductsTableWithData::make();
+    expect($result)->toMatchSnapshot();
+    expect($result->getRecords()[0])->toHaveKey('authorization');
+});
+
+it('includes authorization on records when using Laravel Data with fromModel creation method', function () {
+    Auth::login(UserFactory::new()->create());
+    ProductFactory::createImmutable();
+
+    $result = BasicProductsTableWithDataUsingFromModel::make()->getRecords();
+    expect($result[0])->toHaveKey('authorization');
 });
 
 it('hides hidden refinements, columns and actions in serialization', function () {

--- a/packages/laravel/tests/Laravel/Tables/TableTest.php
+++ b/packages/laravel/tests/Laravel/Tables/TableTest.php
@@ -56,6 +56,17 @@ it('includes authorization on records when using Laravel Data with fromModel cre
     expect($result[0])->toHaveKey('authorization');
 });
 
+it('excludes authorization on records when specified', function () {
+    Auth::login(UserFactory::new()->create());
+    ProductFactory::createImmutable();
+
+    $result = BasicProductsTableWithDataUsingFromModel::make()
+        ->withoutResolvingAuthorizations()
+        ->getRecords();
+
+    expect($result[0])->not->toHaveKey('authorization');
+});
+
 it('hides hidden refinements, columns and actions in serialization', function () {
     ProductFactory::createImmutable();
     expect(BasicProductsTableWithHiddenStuff::make())->toMatchSnapshot();


### PR DESCRIPTION
Hope this helps to resolve the issue of `authorization` missing when using the `fromModel` method. Right now we're having to use `fromModel` for all of our `Data` objects due to this issue: https://github.com/spatie/laravel-data/pull/410#issuecomment-1944121984 (although maybe we should pursue a custom `ModelNormalizer` for our project 🤔)