### PR TITLE
fix(tables): ensure filters are applied when executing bulk actions

### DIFF
--- a/packages/laravel/src/Tables/Actions/Http/InvokedActionController.php
+++ b/packages/laravel/src/Tables/Actions/Http/InvokedActionController.php
@@ -103,7 +103,7 @@ final class InvokedActionController
         $key = $table->getKeyName();
 
         /** @var \Illuminate\Database\Eloquent\Builder */
-        $query = $model::query();
+        $query = $table->getRefinedQuery();
         $query = match (true) {
             $data->all === true => $query->whereNotIn($key, $data->except),
             default => $query->whereIn($key, $data->only)

--- a/packages/laravel/src/Tables/Concerns/RefinesAndPaginateRecords.php
+++ b/packages/laravel/src/Tables/Concerns/RefinesAndPaginateRecords.php
@@ -33,6 +33,11 @@ trait RefinesAndPaginateRecords
         return data_get($this->getPaginatedRecords(), 'data', []);
     }
 
+    public function getRefinedQuery(): Builder
+    {
+        return $this->getRefineInstance()->getBuilderInstance();
+    }
+
     /**
      * Disables authorization resolving.
      */
@@ -141,11 +146,6 @@ trait RefinesAndPaginateRecords
         }
 
         return $this->refine->applyRefiners();
-    }
-
-    protected function getRefinedQuery(): Builder
-    {
-        return $this->getRefineInstance()->getBuilderInstance();
     }
 
     protected function getRefinements(): array

--- a/packages/laravel/tests/Fixtures/Database/Product.php
+++ b/packages/laravel/tests/Fixtures/Database/Product.php
@@ -10,7 +10,9 @@ final class Product extends Model
 {
     use SoftDeletes;
 
+    protected $guarded = [];
     protected $casts = [
+        'is_active' => 'boolean',
         'vendor' => Vendor::class,
     ];
 }

--- a/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithActionsAndFilters.php
+++ b/packages/laravel/tests/Laravel/Tables/Fixtures/BasicProductsTableWithActionsAndFilters.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Hybridly\Tests\Laravel\Tables\Fixtures;
+
+use Hybridly\Refining\Filters\Filter;
+use Hybridly\Tables\Actions\BulkAction;
+use Hybridly\Tables\Columns\TextColumn;
+use Hybridly\Tables\Table;
+use Hybridly\Tests\Fixtures\Database\Product;
+use Illuminate\Support\Collection;
+
+class BasicProductsTableWithActionsAndFilters extends Table
+{
+    protected string $model = Product::class;
+
+    public function defineRefiners(): array
+    {
+        return [
+            Filter::make('vendor'),
+            Filter::make('is_active'),
+        ];
+    }
+
+    public function defineActions(): array
+    {
+        return [
+            BulkAction::make('deactivate')
+                ->action(fn (Collection $records) => $records->each(fn (Product $record) => $record->update(['is_active' => false]))),
+        ];
+    }
+
+    public function defineColumns(): array
+    {
+        return [
+            TextColumn::make('vendor'),
+            TextColumn::make('is_active'),
+        ];
+    }
+}

--- a/packages/vue/src/composables/refinements.ts
+++ b/packages/vue/src/composables/refinements.ts
@@ -347,6 +347,10 @@ export function useRefinements<
 			clear: (options?: AvailableHybridRequestOptions) => clearSorts(options),
 		}))),
 		/**
+		 * The key for the filters.
+		 */
+		filtersKey,
+		/**
 		 * Gets a filter by name.
 		 */
 		getFilter,

--- a/packages/vue/src/composables/table.ts
+++ b/packages/vue/src/composables/table.ts
@@ -118,6 +118,13 @@ export function useTable<
 	async function executeBulkAction(action: Action | string, options?: BulkActionOptions) {
 		const actionName = getActionName(action)
 
+		const filterParameters = refinements.currentFilters().reduce((carry, filter) => {
+			return {
+				...carry,
+				[filter.name]: filter.value,
+			}
+		}, {})
+
 		return await router.navigate({
 			method: 'post',
 			url: route(table.value.endpoint),
@@ -129,6 +136,7 @@ export function useTable<
 				all: bulk.selection.value.all,
 				only: [...bulk.selection.value.only],
 				except: [...bulk.selection.value.except],
+				[refinements.filtersKey.value]: filterParameters,
 			},
 			hooks: {
 				after: () => {


### PR DESCRIPTION
- Updates the `executeBulkAction` on the frontend to send along the currently applied filters inside the POST body
- Update the `InvokeActionController` to pull and use the refined query from the table instead of the table's model's generic query. This will automatically apply the supplied filters from the POST body.

I couldn't find any tests for these pieces, but please point me in the right direction if there are some.