### PR TITLE
test: use `RefreshDatabase` instead of `LazilyRefreshDatabase`

### DIFF
--- a/packages/laravel/tests/TestCase.php
+++ b/packages/laravel/tests/TestCase.php
@@ -5,7 +5,7 @@ namespace Hybridly\Tests;
 use Carbon\Carbon;
 use Hybridly\HybridlyServiceProvider;
 use Hybridly\Tests\Fixtures\Providers\TestingServiceProvider;
-use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\LaravelData\LaravelDataServiceProvider;
@@ -13,7 +13,7 @@ use Spatie\LaravelRay\RayServiceProvider;
 
 class TestCase extends Orchestra
 {
-    use LazilyRefreshDatabase;
+    use RefreshDatabase;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Looks like a change was introduced with Laravel 11 in this PR: https://github.com/laravel/framework/pull/47912

Seems like you now get the same performance out of `RefreshDatabase` as `LazilyRefreshDatabase` when using an in-memory database.