### PR TITLE
fix: Fail global types command and output error if TS transformer fails

### DIFF
--- a/packages/laravel/src/Commands/GenerateGlobalTypesCommand.php
+++ b/packages/laravel/src/Commands/GenerateGlobalTypesCommand.php
@@ -89,9 +89,17 @@ class GenerateGlobalTypesCommand extends Command
     protected function writeTypes(): bool
     {
         if (class_exists(TypeScriptTransformCommand::class)) {
-            Artisan::call(TypeScriptTransformCommand::class, [
+            $exit = Artisan::call(TypeScriptTransformCommand::class, [
                 '--output' => '../.hybridly/php-types.d.ts',
             ]);
+            if ($exit !== 0) {
+                $this->components->error(sprintf(
+                    'Error generating PHP types: %s',
+                    Artisan::output(),
+                ));
+
+                return false;
+            }
         }
 
         $definitions = rescue(fn () => $this->getTypeDefinitions(), rescue: false, report: false);


### PR DESCRIPTION
Currently, if the TypeScript transformer command fails, the error is silently discarded and no `.php-types.d.ts` file is generated:

<img width="767" alt="Screenshot 2024-03-25 at 14 22 23" src="https://github.com/hybridly/hybridly/assets/791222/afe0b3bb-7459-4b38-905b-fa53109b0f37">

This PR will monitor the output of the command and fail the `GenerateGlobalTypesCommand` if the TS transformer command fails. It will also report the output from the TS transformer command:

![Screenshot 2024-03-25 at 14 20 28](https://github.com/hybridly/hybridly/assets/791222/48a694f7-ae04-4ce6-bc31-561109ae7a8c)
