### PR TITLE
refactor(types): improve generation of global types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "phpstan/phpstan-phpunit": "^1.3.11",
         "spatie/laravel-data": "^4.1",
         "spatie/laravel-ray": "^1.32.4",
-        "spatie/laravel-typescript-transformer": "^2.3.0",
+        "spatie/laravel-typescript-transformer": "^2.4",
         "spatie/x-ray": "^1.1.1",
         "symplify/monorepo-builder": "^11.2.3.72"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fed56b97f744c3426e453f075e9f3d06",
+    "content-hash": "15ca8bfd76759c5aee2a23ab3235933e",
     "packages": [
         {
             "name": "amphp/amp",

--- a/packages/laravel/config/hybridly.php
+++ b/packages/laravel/config/hybridly.php
@@ -1,6 +1,7 @@
 <?php
 
 use Hybridly\Support\Configuration\Architecture;
+use Hybridly\Support\TypeScriptTransformer\GlobalPropertiesNamespaceTransformer;
 
 return [
     /*
@@ -86,5 +87,18 @@ return [
     */
     'testing' => [
         'ensure_views_exist' => true,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | TypeScript
+    |--------------------------------------------------------------------------
+    */
+    'typescript' => [
+        'namespace_transformer' => GlobalPropertiesNamespaceTransformer::class,
+        'base_paths' => [
+            base_path('app'),
+            base_path('src'),
+        ],
     ],
 ];

--- a/packages/laravel/src/Commands/GenerateGlobalTypesCommand.php
+++ b/packages/laravel/src/Commands/GenerateGlobalTypesCommand.php
@@ -36,6 +36,10 @@ class GenerateGlobalTypesCommand extends Command
      */
     protected function writePhpTypes(TypeScriptTransformerConfig $config): void
     {
+        if (!class_exists(TypeScriptTransformer::class)) {
+            return;
+        }
+
         $config->outputFile(base_path(self::PHP_TYPES_PATH));
 
         try {

--- a/packages/laravel/src/Commands/GenerateGlobalTypesCommand.php
+++ b/packages/laravel/src/Commands/GenerateGlobalTypesCommand.php
@@ -2,28 +2,102 @@
 
 namespace Hybridly\Commands;
 
+use Hybridly\Exceptions\CouldNotFindMiddlewareException;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use ReflectionMethod;
-use Spatie\LaravelData\Contracts\DataObject;
-use Spatie\LaravelTypeScriptTransformer\Commands\TypeScriptTransformCommand;
+use Spatie\LaravelData\Contracts\BaseData;
 use Spatie\StructureDiscoverer\Discover;
+use Spatie\TypeScriptTransformer\Structures\TransformedType;
+use Spatie\TypeScriptTransformer\TypeScriptTransformer;
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
 class GenerateGlobalTypesCommand extends Command
 {
+    protected const PHP_TYPES_PATH = '.hybridly/php-types.d.ts';
+    protected const GLOBAL_PROPERTIES_PATH = '.hybridly/global-properties.d.ts';
+
     protected $signature = 'hybridly:types';
     protected $description = 'Generates the global types definitions for the front-end.';
     protected $hidden = true;
 
-    public function handle(): int
+    protected int $exitCode = self::SUCCESS;
+
+    public function handle(TypeScriptTransformerConfig $typeScriptTransformerConfig): int
     {
-        return $this->writeTypes()
-            ? self::SUCCESS
-            : self::FAILURE;
+        $this->writePhpTypes($typeScriptTransformerConfig);
+        $this->writeGlobalPropertiesInterface();
+
+        return $this->exitCode;
     }
 
-    protected function getTypeDefinitions(): ?string
+    /**
+     * Converts PHP types to TypeScript types.
+     */
+    protected function writePhpTypes(TypeScriptTransformerConfig $config): void
+    {
+        $config->outputFile(base_path(self::PHP_TYPES_PATH));
+
+        try {
+            $collection = (new TypeScriptTransformer($config))->transform();
+        } catch (\Exception $exception) {
+            $this->components->error($exception->getMessage());
+            $this->exitCode = self::FAILURE;
+
+            return;
+        }
+
+        if ($this->output->isVerbose()) {
+            $this->table(
+                ['PHP class', 'TypeScript entity'],
+                collect($collection)->map(fn (TransformedType $type, string $class) => [
+                    $class,
+                    $type->getTypeScriptName(),
+                ]),
+            );
+        }
+
+        $this->components->info(sprintf(
+            '%s PHP types written to <comment>%s</comment>.',
+            $collection->count(),
+            self::PHP_TYPES_PATH,
+        ));
+    }
+
+    /**
+     * Writes the global properties interface.
+     */
+    protected function writeGlobalPropertiesInterface(): void
+    {
+        try {
+            $namespace = $this->getGlobalPropertiesNamespace();
+        } catch (\Exception $exception) {
+            $this->components->error($exception->getMessage());
+            $this->exitCode = self::FAILURE;
+        }
+
+        $namespace ??= null;
+
+        File::put(
+            base_path(self::GLOBAL_PROPERTIES_PATH),
+            $this->getGlobalHybridPropertiesInterface($namespace),
+        );
+
+        $message = $namespace
+            ? sprintf('Interface <comment>%s</comment>', $namespace)
+            : 'Empty interface';
+
+        $this->components->info(sprintf(
+            '%s written to <comment>%s</comment>.',
+            $message,
+            self::GLOBAL_PROPERTIES_PATH,
+        ));
+    }
+
+    /**
+     * Extracts the namespace of the global properties data class used in the Hybridly middleware.
+     */
+    protected function getGlobalPropertiesNamespace(): ?string
     {
         $directories = array_filter([
             base_path('app'),
@@ -36,10 +110,10 @@ class GenerateGlobalTypesCommand extends Command
             ->ignoreFiles(base_path('resources'))
             ->classes()
             ->extending(\Hybridly\Http\Middleware::class)
-            ->get();
+            ->get() + [null];
 
         if (!$class) {
-            return null;
+            throw CouldNotFindMiddlewareException::create();
         }
 
         $methods = (new \ReflectionClass($class))->getMethods(\ReflectionMethod::IS_PUBLIC);
@@ -59,61 +133,32 @@ class GenerateGlobalTypesCommand extends Command
             return null;
         }
 
-        if (!class_implements($data, DataObject::class)) {
+        if (!class_implements($data, BaseData::class)) {
             return null;
         }
 
-        $namespace = str_replace('\\', '.', $data);
-
-        return $this->getGlobalHybridPropertiesInterface($namespace);
+        return $data;
     }
 
+    /**
+     * Gets the global properties interface code.
+     */
     protected function getGlobalHybridPropertiesInterface(?string $namespace = null): string
     {
         if ($namespace) {
-            return <<<TYPESCRIPT
+            $namespace = str_replace('\\', '.', $namespace);
+
+            return <<<JS
+                /* eslint-disable */
+                /* prettier-ignore */
+                interface GlobalHybridlyProperties extends {$namespace} {}
+            JS;
+        }
+
+        return <<<JS
             /* eslint-disable */
             /* prettier-ignore */
-            interface GlobalHybridlyProperties extends {$namespace} {
-            }
-            TYPESCRIPT;
-        }
-
-        return <<<TYPESCRIPT
-        /* eslint-disable */
-        /* prettier-ignore */
-        type GlobalHybridlyProperties = never
-        TYPESCRIPT;
-    }
-
-    protected function writeTypes(): bool
-    {
-        if (class_exists(TypeScriptTransformCommand::class)) {
-            Artisan::call(TypeScriptTransformCommand::class, [
-                '--output' => '../.hybridly/php-types.d.ts',
-            ]);
-        }
-
-        $definitions = rescue(fn () => $this->getTypeDefinitions(), rescue: false, report: false);
-        $result = (bool) File::put(
-            $path = base_path('.hybridly/global-types.d.ts'),
-            $definitions ?? $this->getGlobalHybridPropertiesInterface(),
-        );
-
-        if ($result) {
-            $this->writeSuccess($path);
-        }
-
-        return $result;
-    }
-
-    protected function writeSuccess(string $path): void
-    {
-        $this->components->info(
-            sprintf(
-                'Types written to <comment>%s</comment>.',
-                $path,
-            ),
-        );
+            type GlobalHybridlyProperties = never;
+        JS;
     }
 }

--- a/packages/laravel/src/Exceptions/CouldNotFindMiddlewareException.php
+++ b/packages/laravel/src/Exceptions/CouldNotFindMiddlewareException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Hybridly\Exceptions;
+
+use Exception;
+
+final class CouldNotFindMiddlewareException extends Exception
+{
+    public static function create(): self
+    {
+        return new self('Could not find the Hybridly middleware in the application.');
+    }
+}

--- a/packages/laravel/src/Support/Configuration/Configuration.php
+++ b/packages/laravel/src/Support/Configuration/Configuration.php
@@ -13,6 +13,7 @@ final class Configuration
         public readonly Internationalization $internationalization,
         public readonly Properties $properties,
         public readonly Testing $testing,
+        public readonly TypeScript $typescript,
     ) {
     }
 
@@ -26,6 +27,7 @@ final class Configuration
             internationalization: Internationalization::fromArray($config['internationalization'] ?? []),
             properties: Properties::fromArray($config['properties'] ?? []),
             testing: Testing::fromArray($config['testing'] ?? []),
+            typescript: TypeScript::fromArray($config['typescript'] ?? []),
         );
     }
 

--- a/packages/laravel/src/Support/Configuration/TypeScript.php
+++ b/packages/laravel/src/Support/Configuration/TypeScript.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Hybridly\Support\Configuration;
+
+use Hybridly\Support\TypeScriptTransformer\GlobalPropertiesNamespaceTransformer;
+
+final class TypeScript
+{
+    public function __construct(
+        public array $basePaths,
+        public ?string $namespaceTransformer,
+    ) {
+    }
+
+    public static function fromArray(array $config): static
+    {
+        return new static(
+            basePaths: $config['base_paths'] ?? [
+                base_path('app'),
+                base_path('src'),
+            ],
+            namespaceTransformer: $config['namespace_transformer'] ?? GlobalPropertiesNamespaceTransformer::class,
+        );
+    }
+}

--- a/packages/laravel/src/Support/TypeScriptTransformer/GlobalPropertiesNamespaceTransformer.php
+++ b/packages/laravel/src/Support/TypeScriptTransformer/GlobalPropertiesNamespaceTransformer.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Hybridly\Support\TypeScriptTransformer;
+
+final class GlobalPropertiesNamespaceTransformer
+{
+    public function __invoke(?string $namespace = null): ?string
+    {
+        if (!$namespace) {
+            return null;
+        }
+
+        return str_replace('\\', '.', $namespace);
+    }
+}

--- a/packages/laravel/tests/Laravel/Commands/Fixtures/CustomTransformer.php
+++ b/packages/laravel/tests/Laravel/Commands/Fixtures/CustomTransformer.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Hybridly\Tests\Laravel\Commands\Fixtures;
+
+final class CustomTransformer
+{
+    public function __invoke(?string $namespace): ?string
+    {
+        if (!$namespace) {
+            return null;
+        }
+
+        return str_replace('App.', '', str_replace('\\', '.', $namespace));
+    }
+}

--- a/packages/laravel/tests/Laravel/Commands/GenerateGlobalTypesCommandTest.php
+++ b/packages/laravel/tests/Laravel/Commands/GenerateGlobalTypesCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Hybridly\Support\Configuration\Configuration;
+use Hybridly\Tests\Laravel\Commands\Fixtures\CustomTransformer;
 use Illuminate\Support\Facades\File;
 
 use function Pest\Laravel\artisan;
@@ -59,4 +61,19 @@ it('generates php types', function () {
     expect(File::get(base_path('.hybridly/php-types.d.ts')))
         ->toContain('UserData')
         ->toContain('SharedData');
+})->skip('Does not work, probably due to where the Laravel skeleton is');
+
+it('accepts custom transformers', function () {
+    Configuration::get()->typescript->namespaceTransformer = CustomTransformer::class;
+
+    copy_stubs([
+        'UserData.php' => 'app/Data',
+    ]);
+
+    artisan('hybridly:types');
+
+    expect(File::exists(base_path('.hybridly/php-types.d.ts')))->toBeTrue();
+    expect(File::get(base_path('.hybridly/php-types.d.ts')))
+        ->toContain('Data.UserData')
+        ->not->toContain('App.Data.UserData');
 })->skip('Does not work, probably due to where the Laravel skeleton is');

--- a/packages/laravel/tests/Laravel/Commands/GenerateGlobalTypesCommandTest.php
+++ b/packages/laravel/tests/Laravel/Commands/GenerateGlobalTypesCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+
+use function Pest\Laravel\artisan;
+
+beforeEach(function () {
+    File::cleanDirectory(base_path('.hybridly'));
+    File::cleanDirectory(base_path('app/Data'));
+    File::cleanDirectory(base_path('app/Http/Middleware'));
+});
+
+function copy_stubs(array $paths): void
+{
+    foreach ($paths as $stub => $directory) {
+        File::makeDirectory(base_path($directory), recursive: true, force: true);
+        File::copy(
+            path: __DIR__ . '/stubs/' . $stub,
+            target: base_path($directory . '/' . $stub),
+        );
+    }
+}
+
+it('fails the command when there is no middleware, but still generates types', function () {
+    copy_stubs([
+        'UserData.php' => 'app/Data',
+    ]);
+
+    artisan('hybridly:types')
+        ->assertExitCode(1)
+        ->expectsOutputToContain('Could not find the Hybridly middleware in the application.');
+
+    expect(File::exists(base_path('.hybridly/global-properties.d.ts')))->toBeTrue();
+    expect(File::exists(base_path('.hybridly/php-types.d.ts')))->toBeTrue();
+});
+
+it('succeeds when the middleware exists and generates types', function () {
+    copy_stubs([
+        'UserData.php' => 'app/Data',
+        'SharedData.php' => 'app/Data',
+        'HandleHybridRequests.php' => 'app/Http/Middleware',
+    ]);
+
+    artisan('hybridly:types')->assertExitCode(0);
+
+    expect(File::exists(base_path('.hybridly/php-types.d.ts')))->toBeTrue();
+    expect(File::exists(base_path('.hybridly/global-properties.d.ts')))->toBeTrue();
+})->skip('Does not work, probably due to where the Laravel skeleton is');
+
+it('generates php types', function () {
+    copy_stubs([
+        'UserData.php' => 'app/Data',
+        'SharedData.php' => 'app/Data',
+    ]);
+
+    artisan('hybridly:types')->assertExitCode(1);
+
+    expect(File::exists(base_path('.hybridly/php-types.d.ts')))->toBeTrue();
+    expect(File::get(base_path('.hybridly/php-types.d.ts')))
+        ->toContain('UserData')
+        ->toContain('SharedData');
+})->skip('Does not work, probably due to where the Laravel skeleton is');

--- a/packages/laravel/tests/Laravel/Commands/stubs/HandleHybridRequests.php
+++ b/packages/laravel/tests/Laravel/Commands/stubs/HandleHybridRequests.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Data\SharedData;
+use App\Data\UserData;
+use Hybridly\Http\Middleware;
+
+final class HandleHybridRequests extends Middleware
+{
+    /**
+     * Defines the properties that are shared to all requests.
+     */
+    public function share(): SharedData
+    {
+        return SharedData::from([
+            'user' => UserData::optional(auth()->user()),
+        ]);
+    }
+}

--- a/packages/laravel/tests/Laravel/Commands/stubs/SharedData.php
+++ b/packages/laravel/tests/Laravel/Commands/stubs/SharedData.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Data\SharedData;
+
+use App\Data\UserData;
+use Spatie\LaravelData\Data;
+
+final class SharedData extends Data
+{
+    public function __construct(
+        public readonly ?UserData $user,
+    ) {
+    }
+}

--- a/packages/laravel/tests/Laravel/Commands/stubs/UserData.php
+++ b/packages/laravel/tests/Laravel/Commands/stubs/UserData.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Data\UserData;
+
+use Spatie\LaravelData\Data;
+
+final class UserData extends Data
+{
+    public function __construct(
+        public readonly string $username,
+    ) {
+    }
+}

--- a/packages/laravel/tests/TestCase.php
+++ b/packages/laravel/tests/TestCase.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\LaravelData\LaravelDataServiceProvider;
 use Spatie\LaravelRay\RayServiceProvider;
+use Spatie\LaravelTypeScriptTransformer\TypeScriptTransformerServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -29,6 +30,7 @@ class TestCase extends Orchestra
             TestingServiceProvider::class,
             HybridlyServiceProvider::class,
             LaravelDataServiceProvider::class,
+            TypeScriptTransformerServiceProvider::class,
             RayServiceProvider::class,
         ];
     }

--- a/packages/vite/src/typegen/index.ts
+++ b/packages/vite/src/typegen/index.ts
@@ -47,7 +47,7 @@ export function generateTsConfig(options: ViteOptions, config: DynamicConfigurat
 			'../app/**/*',
 			'../src/**/*',
 			'./php-types.d.ts',
-			'./global-types.d.ts',
+			'./global-properties.d.ts',
 			'./routes.d.ts',
 			'./components.d.ts',
 			'./auto-imports.d.ts',


### PR DESCRIPTION
This pull request refactors the global types generation:
- The code is a bit cleaned up
- Tests have been added
- The commands now fails when there is no middleware
- The command still does not fail if the middleware does not return a DTO
- The command now fails if PHP types cannot be generated
- The command does not fail if `typescript-transformer` is not installed
- When running `hybridly:types` manually, exceptions are shown
- It is now possible to override the base paths used to find types
- It is now possible to override how the global properties namespace is transformed

Note: couldn't manage to make two of the tests work, I assume due to an issue with where the testbench's Laravel skeleton is. Will dig into it later™.

Closes #136
Co-Authored-By: @owenconti 