### PR TITLE
fix(tables): take `withoutResolvingAuthorizations` into account on data objects using custom `fromModel`

### DIFF
--- a/packages/laravel/src/Tables/Concerns/RefinesAndPaginateRecords.php
+++ b/packages/laravel/src/Tables/Concerns/RefinesAndPaginateRecords.php
@@ -162,6 +162,8 @@ trait RefinesAndPaginateRecords
                 $record->additional([
                     'authorization' => fn () => resolve(AuthorizationArrayResolver::class)->resolve($model, $this->data),
                 ]);
+            } else {
+                $record->excludePermanently('authorization');
             }
 
             return $record->toArray();

--- a/packages/laravel/src/Tables/Concerns/RefinesAndPaginateRecords.php
+++ b/packages/laravel/src/Tables/Concerns/RefinesAndPaginateRecords.php
@@ -5,7 +5,6 @@ namespace Hybridly\Tables\Concerns;
 use Hybridly\Refining\Contracts\Refiner;
 use Hybridly\Refining\Refine;
 use Hybridly\Support\Configuration\Configuration;
-use Hybridly\Support\Data\AuthorizationArrayResolver;
 use Hybridly\Tables\Columns\BaseColumn;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
@@ -158,11 +157,7 @@ trait RefinesAndPaginateRecords
         if (isset($this->data) && is_a($this->data, Data::class, allow_string: true)) {
             $record = $this->resolveDataRecord($model);
 
-            if ($this->resolvesAuthorizations()) {
-                $record->additional([
-                    'authorization' => fn () => resolve(AuthorizationArrayResolver::class)->resolve($model, $this->data),
-                ]);
-            } else {
+            if (!$this->resolvesAuthorizations()) {
                 $record->excludePermanently('authorization');
             }
 

--- a/packages/laravel/tests/.pest/snapshots/Laravel/Tables/TableTest/it_includes_authorization_on_records_by_default.snap
+++ b/packages/laravel/tests/.pest/snapshots/Laravel/Tables/TableTest/it_includes_authorization_on_records_by_default.snap
@@ -1,0 +1,71 @@
+{
+    "id": "products-table",
+    "keyName": "id",
+    "refinements": {
+        "sorts": [],
+        "filters": [],
+        "scope": null,
+        "keys": {
+            "sorts": "sort",
+            "filters": "filters"
+        }
+    },
+    "records": [
+        {
+            "name": "AirPods",
+            "created_at": "2021-01-01T00:00:00+00:00",
+            "authorization": {
+                "returns-true": true,
+                "returns-false": false
+            }
+        }
+    ],
+    "paginator": {
+        "links": [
+            {
+                "url": null,
+                "label": "&laquo; Previous",
+                "active": false
+            },
+            {
+                "url": "http:\/\/localhost?page=1",
+                "label": "1",
+                "active": true
+            },
+            {
+                "url": null,
+                "label": "Next &raquo;",
+                "active": false
+            }
+        ],
+        "meta": {
+            "current_page": 1,
+            "first_page_url": "http:\/\/localhost?page=1",
+            "from": 1,
+            "last_page": 1,
+            "last_page_url": "http:\/\/localhost?page=1",
+            "path": "http:\/\/localhost",
+            "per_page": 10,
+            "to": 1,
+            "total": 1
+        }
+    },
+    "columns": [
+        {
+            "name": "name",
+            "type": "text",
+            "label": "Name",
+            "metadata": []
+        },
+        {
+            "name": "created_at",
+            "type": "text",
+            "label": "Created at",
+            "metadata": []
+        }
+    ],
+    "endpoint": "hybridly.action.invoke",
+    "inlineActions": [],
+    "bulkActions": [],
+    "scope": null
+}

--- a/packages/laravel/tests/Laravel/Tables/Fixtures/ProductNameDataUsingFromModel.php
+++ b/packages/laravel/tests/Laravel/Tables/Fixtures/ProductNameDataUsingFromModel.php
@@ -5,6 +5,7 @@ namespace Hybridly\Tests\Laravel\Tables\Fixtures;
 use Carbon\CarbonInterface;
 use Hybridly\Support\Data\DataResource;
 use Hybridly\Tests\Fixtures\Database\Product;
+use Spatie\LaravelData\Lazy;
 
 class ProductNameDataUsingFromModel extends DataResource
 {
@@ -21,9 +22,12 @@ class ProductNameDataUsingFromModel extends DataResource
 
     public static function fromModel(Product $product): static
     {
-        return new static(
-            name: $product->name,
-            created_at: $product->created_at,
-        );
+        return static::factory()
+            ->withoutMagicalCreation()
+            ->from([
+                'name' => $product->name,
+                'created_at' => $product->created_at,
+                'authorization' => Lazy::create(fn () => static::resolveAuthorizationArray($product))->defaultIncluded(),
+            ]);
     }
 }

--- a/packages/laravel/tests/Laravel/Tables/TableTest.php
+++ b/packages/laravel/tests/Laravel/Tables/TableTest.php
@@ -63,6 +63,17 @@ it('excludes authorization on records when specified', function () {
     Auth::login(UserFactory::new()->create());
     ProductFactory::createImmutable();
 
+    $result = BasicProductsTableWithData::make()
+        ->withoutResolvingAuthorizations()
+        ->getRecords();
+
+    expect($result[0])->not->toHaveKey('authorization');
+});
+
+it('excludes authorization when specified on records using fromModel creation method', function () {
+    Auth::login(UserFactory::new()->create());
+    ProductFactory::createImmutable();
+
     $result = BasicProductsTableWithDataUsingFromModel::make()
         ->withoutResolvingAuthorizations()
         ->getRecords();

--- a/packages/laravel/tests/Laravel/Tables/TableTest.php
+++ b/packages/laravel/tests/Laravel/Tables/TableTest.php
@@ -42,7 +42,7 @@ it('can transform records using Laravel Data', function () {
     expect(BasicProductsTableWithData::make())->toMatchSnapshot();
 });
 
-it('includes authorization on records when using Laravel Data', function () {
+it('includes authorization on records by default', function () {
     Auth::login(UserFactory::new()->create());
     ProductFactory::createImmutable();
 
@@ -51,13 +51,14 @@ it('includes authorization on records when using Laravel Data', function () {
     expect($result->getRecords()[0])->toHaveKey('authorization');
 });
 
-it('includes authorization on records when using Laravel Data with fromModel creation method', function () {
+it('includes authorization on records using custom `fromModel` by default', function () {
     Auth::login(UserFactory::new()->create());
     ProductFactory::createImmutable();
 
     $result = BasicProductsTableWithDataUsingFromModel::make()->getRecords();
     expect($result[0])->toHaveKey('authorization');
     expect($result[0]['authorization']['returns-true'])->toBeTrue();
+    expect($result[0]['authorization']['returns-false'])->toBeFalse();
 });
 
 it('excludes authorization on records when specified', function () {
@@ -71,7 +72,7 @@ it('excludes authorization on records when specified', function () {
     expect($result[0])->not->toHaveKey('authorization');
 });
 
-it('excludes authorization when specified on records using fromModel creation method', function () {
+it('excludes authorization on records using custom `fromModel` when specified', function () {
     Auth::login(UserFactory::new()->create());
     ProductFactory::createImmutable();
 

--- a/packages/laravel/tests/Laravel/Tables/TableTest.php
+++ b/packages/laravel/tests/Laravel/Tables/TableTest.php
@@ -57,6 +57,7 @@ it('includes authorization on records when using Laravel Data with fromModel cre
 
     $result = BasicProductsTableWithDataUsingFromModel::make()->getRecords();
     expect($result[0])->toHaveKey('authorization');
+    expect($result[0]['authorization']['returns-true'])->toBeTrue();
 });
 
 it('excludes authorization on records when specified', function () {


### PR DESCRIPTION
First off, I apologize if I am using the new `withoutAuthorizations()` incorrectly.

When using  the `withoutAuthorizations()` on a table that has a `Data` record that **does not** use a custom `fromModel` method, the authorizations are not being excluded:

```php
$table = IndexAlertTable::make()->withoutResolvingAuthorizations();
``` 

I believe this is happening because the abstract `DataResource` includes the `authorization` key by default via the pipeline:

```php
    public static function pipeline(): DataPipeline
    {
        return parent::pipeline()->firstThrough(ResolveAuthorizationsPipe::class);
    }
```

The application of the `authorization` key within the `$this->resolvesAuthorizations()` check is redundant because:

1. If the `Data` class does not have a `fromModel` then the default pipeline will add the `authorization` key.
2. If the `Data` class does have a custom `fromModel` then the user must manually add the `authorization` key via `resolveAuthorizationArray`.

I _think_ maybe what you would want to do is replace the `$this->resolvesAuthorizations()` check with the inverse and then exclude the authorizations if they are to not be resolved.

Our current workaround for this is to override the `resolveDataRecord` method in our tables and exclude the `authorization` key:

```php
    protected function resolveDataRecord(Model $model): Data
    {
        return $this->data::from($model)->excludePermanently('authorization');
    }
```
