### PR TITLE
feat(form): add method to reset submission state

### DIFF
--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -92,3 +92,7 @@ interface MockOptions {
 	json?: any
 	body?: any
 }
+
+export function delay(time: number) {
+	return new Promise((resolve) => setTimeout(resolve, time))
+}

--- a/packages/vue/src/composables/form.ts
+++ b/packages/vue/src/composables/form.ts
@@ -102,18 +102,18 @@ export function useForm<
 	}
 
 	/**
-	 * Resets the form to it's initial state (including errors and flags).
+	 * Resets the fields, errors and submission state.
 	 */
-	function fullyReset() {
+	function reset() {
 		resetSubmissionState()
 		clearErrors()
-		reset()
+		resetFields()
 	}
 
 	/**
-	 * Resets the form to its initial values.
+	 * Resets the fields to their initial values.
 	 */
-	function reset(...keys: P[]) {
+	function resetFields(...keys: P[]) {
 		if (keys.length === 0) {
 			keys = Object.keys(fields) as P[]
 		}
@@ -188,7 +188,7 @@ export function useForm<
 						setInitial(fields)
 					}
 					if (optionsWithOverrides.reset !== false) {
-						reset()
+						resetFields()
 					}
 					successful.value = true
 					recentlySuccessful.value = true
@@ -264,6 +264,7 @@ export function useForm<
 	}, { deep: true, immediate: true })
 
 	return reactive({
+		resetFields,
 		reset,
 		resetSubmissionState,
 		clear,
@@ -274,7 +275,6 @@ export function useForm<
 		clearError,
 		setInitial,
 		hasDirty,
-		fullyReset,
 		submitWith: submit,
 		/** @deprecated Use `submitWith` instead */
 		submitWithOptions: submit,

--- a/packages/vue/src/composables/form.ts
+++ b/packages/vue/src/composables/form.ts
@@ -88,11 +88,26 @@ export function useForm<
 		})
 	}
 
+	/**
+	 * Resets the form's failed and successful flags.
+	 */
 	function resetSubmissionState() {
-		successful.value = failed.value = recentlyFailed.value = recentlySuccessful.value = false
+		successful.value = false
+		failed.value = false
+		recentlyFailed.value = false
+		recentlySuccessful.value = false
 		clearTimeout(timeoutIds.recentlySuccessful!)
 		clearTimeout(timeoutIds.recentlyFailed!)
 		progress.value = undefined
+	}
+
+	/**
+	 * Resets the form to it's initial state (including errors and flags).
+	 */
+	function fullyReset() {
+		resetSubmissionState()
+		clearErrors()
+		reset()
 	}
 
 	/**
@@ -100,11 +115,8 @@ export function useForm<
 	 */
 	function reset(...keys: P[]) {
 		if (keys.length === 0) {
-			resetSubmissionState()
 			keys = Object.keys(fields) as P[]
 		}
-
-		clearErrors(...keys)
 
 		keys.forEach((key) => {
 			Reflect.set(fields, key, safeClone(Reflect.get(initial, key)))
@@ -171,13 +183,12 @@ export function useForm<
 					return hooks.error?.(incoming, context)
 				},
 				success: (payload, context) => {
+					clearErrors()
 					if (optionsWithOverrides.updateInitials) {
 						setInitial(fields)
 					}
 					if (optionsWithOverrides.reset !== false) {
 						reset()
-					} else {
-						clearErrors()
 					}
 					successful.value = true
 					recentlySuccessful.value = true
@@ -263,6 +274,7 @@ export function useForm<
 		clearError,
 		setInitial,
 		hasDirty,
+		fullyReset,
 		submitWith: submit,
 		/** @deprecated Use `submitWith` instead */
 		submitWithOptions: submit,

--- a/packages/vue/test/form.test.ts
+++ b/packages/vue/test/form.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, it, vi } from 'vitest'
 import { useForm } from '@hybridly/vue'
 import { nextTick } from 'vue'
-import { fakeRouterContext, mockSuccessfulUrl, mockInvalidUrl } from '../../core/test/utils'
+import { fakeRouterContext, mockSuccessfulUrl, mockInvalidUrl, delay } from '../../core/test/utils'
 import { server } from '../../core/test/server'
 
 beforeEach(async() => {
@@ -54,6 +54,71 @@ it('it does not reset dirty state after failed form submission', async({ expect 
 	// Then
 	await nextTick()
 	expect(form.isDirty).toBe(true)
+})
+
+it('it updates failed and successful', async({ expect }) => {
+	server.resetHandlers(mockSuccessfulUrl('http://localhost.test/navigation', 'post'))
+
+	const form = useForm({
+		url: 'http://localhost.test/navigation',
+		timeout: 10,
+		fields: {
+		},
+		reset: false,
+	})
+
+	expect(form.successful).toBe(false)
+	expect(form.recentlySuccessful).toBe(false)
+	expect(form.failed).toBe(false)
+	expect(form.recentlyFailed).toBe(false)
+	expect(form.processing).toBe(false)
+
+	await form.submitWith({
+		hooks: {
+			start() {
+				expect(form.processing).toBe(true)
+			},
+		},
+	})
+
+	expect(form.successful).toBe(true)
+	expect(form.recentlySuccessful).toBe(true)
+	expect(form.failed).toBe(false)
+	expect(form.recentlyFailed).toBe(false)
+	expect(form.processing).toBe(false)
+
+	await delay(10)
+	expect(form.successful).toBe(true)
+	expect(form.recentlySuccessful).toBe(false)
+
+	form.reset()
+	expect(form.successful).toBe(false)
+
+	await form.submit() // Retrigger submission to have successful = true
+
+	expect(form.successful).toBe(true)
+
+	server.resetHandlers(mockInvalidUrl('http://localhost.test/navigation', 'post'))
+
+	await form.submitWith({
+		hooks: {
+			before() {
+				expect(form.successful).toBe(false)
+			},
+		},
+	})
+
+	expect(form.successful).toBe(false)
+	expect(form.recentlySuccessful).toBe(false)
+	expect(form.failed).toBe(true)
+	expect(form.recentlyFailed).toBe(true)
+
+	await delay(10)
+	expect(form.failed).toBe(true)
+	expect(form.recentlyFailed).toBe(false)
+
+	form.reset()
+	expect(form.failed).toBe(false)
 })
 
 it('it can override all options', async({ expect }) => {

--- a/packages/vue/test/form.test.ts
+++ b/packages/vue/test/form.test.ts
@@ -91,7 +91,7 @@ it('it updates failed and successful', async({ expect }) => {
 	expect(form.successful).toBe(true)
 	expect(form.recentlySuccessful).toBe(false)
 
-	form.reset()
+	form.resetSubmissionState()
 	expect(form.successful).toBe(false)
 
 	await form.submit() // Retrigger submission to have successful = true
@@ -117,7 +117,7 @@ it('it updates failed and successful', async({ expect }) => {
 	expect(form.failed).toBe(true)
 	expect(form.recentlyFailed).toBe(false)
 
-	form.reset()
+	form.resetSubmissionState()
 	expect(form.failed).toBe(false)
 })
 


### PR DESCRIPTION
There is currently no way to reset `form.(recently)successful` or `form.(recently)failed`

I believe they should reset automatically when the form is reset

As such I changed the default behavior of `reset` to reset those if no keys are passed

And to also clear the errors of all the fields that are reset