### PR TITLE
feat(exceptions): implement new exception API

### DIFF
--- a/packages/laravel/src/Concerns/HandlesHybridExceptions.php
+++ b/packages/laravel/src/Concerns/HandlesHybridExceptions.php
@@ -9,7 +9,10 @@ use Illuminate\Foundation\ViteManifestNotFoundException;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/** @mixin Handler */
+/**
+ * @mixin Handler
+ * @deprecated Use `\Hybridly\Exceptions\HandleHybridExceptions` instead.
+ */
 trait HandlesHybridExceptions
 {
     /**

--- a/packages/laravel/src/Exceptions/HandleHybridExceptions.php
+++ b/packages/laravel/src/Exceptions/HandleHybridExceptions.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Hybridly\Exceptions;
+
+use Exception;
+use Hybridly\Components\Concerns\EvaluatesClosures;
+use Hybridly\Contracts\HybridResponse;
+use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Foundation\ViteManifestNotFoundException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Symfony\Component\HttpFoundation\Response;
+
+class HandleHybridExceptions
+{
+    use EvaluatesClosures;
+
+    /**
+     * List of HTTP status codes that Hybridly will handle.
+     */
+    protected array $statusCodes = [
+        Response::HTTP_INTERNAL_SERVER_ERROR,
+        Response::HTTP_SERVICE_UNAVAILABLE,
+        Response::HTTP_NOT_FOUND,
+        Response::HTTP_FORBIDDEN,
+        Response::HTTP_UNAUTHORIZED,
+    ];
+
+    /**
+     * Environments in which the exceptions are handled.
+     */
+    protected array $environments = ['production'];
+
+    protected array $withExceptionsCallbacks = [];
+    protected null|\Closure $renderUsingCallback = null;
+    protected null|\Closure $expireSessionUsingCallback = null;
+
+    public function __invoke(Exceptions $exceptions): void
+    {
+        foreach ($this->withExceptionsCallbacks as $callback) {
+            $callback($exceptions);
+        }
+
+        $exceptions->respond($this->respondUsing(...));
+    }
+
+    /**
+     * Registers the exception handler.
+     */
+    public static function register(): static
+    {
+        return new static();
+    }
+
+    /**
+     * Defines the response that will be rendered when an exception occurs.
+     */
+    public function renderUsing(callable $callback): static
+    {
+        $this->renderUsingCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Defines the response that will be rendered when the session is expired.
+     */
+    public function expireSessionUsing(callable $callback): static
+    {
+        $this->expireSessionUsingCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Hooks into the underlying exception handler.
+     */
+    public function withExceptions(callable $callback): static
+    {
+        $this->withExceptionsCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Only handle the specified status codes.
+     */
+    public function handleStatusCodes(string|array $codes): static
+    {
+        $this->statusCodes = Arr::wrap($codes);
+
+        return $this;
+    }
+
+    /**
+     * Specify in which environments the handling should be done.
+     */
+    public function inEnvironments(null|string|array $environments = null): static
+    {
+        if (!\is_null($environments)) {
+            $this->environments = Arr::wrap($environments);
+        }
+
+        return $this;
+    }
+
+    protected function respondUsing(Response $response, \Throwable $e, Request $request): Response
+    {
+        if ($this->shouldHandleTokenMismatch($response, $request, $e)) {
+            return $this->onSessionExpired($response, $request, $e);
+        }
+
+        if ($this->shouldRenderHybridResponse($response, $request, $e)) {
+            return $this->renderHybridResponse($response, $request, $e)
+                ->toResponse($request)
+                ->setStatusCode($response->status());
+        }
+
+        return $response;
+    }
+
+    protected function onSessionExpired(Response $response, Request $request, \Throwable $e): mixed
+    {
+        $callback = $this->expireSessionUsingCallback ?? fn () => redirect()->back()->with([
+            'error' => 'Your session has expired. Please refresh the page.',
+        ]);
+
+        return $this->evaluate($callback, [
+            'response' => $response,
+            'request' => $request,
+            'exception' => $e,
+        ], [
+            Response::class => $response,
+            Request::class => $request,
+            \Throwable::class => $e,
+            \Exception::class => $e,
+        ]);
+    }
+
+    protected function renderHybridResponse(Response $response, Request $request, \Throwable $e): HybridResponse
+    {
+        if (\is_null($this->renderUsingCallback)) {
+            throw new Exception('The `renderHybridResponse` method is not implemented.');
+        }
+
+        return $this->evaluate($this->renderUsingCallback, [
+            'response' => $response,
+            'request' => $request,
+            'exception' => $e,
+            'e' => $e,
+        ], [
+            Response::class => $response,
+            Request::class => $request,
+            \Throwable::class => $e,
+            \Exception::class => $e,
+        ]);
+    }
+
+    protected function shouldRenderHybridResponse(Response $response, Request $request, \Throwable $e): bool
+    {
+        if ($e instanceof ViteManifestNotFoundException) {
+            return false;
+        }
+
+        if (!app()->environment($this->environments)) {
+            return false;
+        }
+
+        return \in_array($response->status(), $this->statusCodes, strict: true);
+    }
+
+    protected function shouldHandleTokenMismatch(Response $response, Request $request, \Throwable $e): bool
+    {
+        return $response->status() === 419;
+    }
+}

--- a/packages/laravel/tests/Laravel/Exceptions/HandleHybridExceptions.php
+++ b/packages/laravel/tests/Laravel/Exceptions/HandleHybridExceptions.php
@@ -1,0 +1,92 @@
+<?php
+
+use Hybridly\Exceptions\HandleHybridExceptions;
+use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Http\Response;
+use Illuminate\Session\TokenMismatchException;
+use Illuminate\Support\Facades\Route;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use function Hybridly\view;
+use function Pest\Laravel\get;
+
+function register_handler(callable $using)
+{
+    app()->singleton(
+        \Illuminate\Contracts\Debug\ExceptionHandler::class,
+        \Illuminate\Foundation\Exceptions\Handler::class,
+    );
+
+    app()->afterResolving(
+        \Illuminate\Foundation\Exceptions\Handler::class,
+        fn ($handler) => $using(new Exceptions($handler)),
+    );
+}
+
+test('exceptions are rendered using the specified callback', function () {
+    register_handler(
+        HandleHybridExceptions::register()
+            ->inEnvironments('testing')
+            ->renderUsing(fn (Response $response) => view('error', [
+                'status' => $response->getStatusCode(),
+            ])),
+    );
+
+    Route::get('/404', fn () => throw new NotFoundHttpException());
+
+    get('404')
+        ->assertHybridView('error')
+        ->assertHybridProperties([
+            'status' => 404,
+        ]);
+});
+
+test('session expiration are rendered using the specified callback', function () {
+    register_handler(
+        HandleHybridExceptions::register()
+            ->inEnvironments('testing')
+            ->renderUsing(fn (\Throwable $e) => view('error', ['message' => $e->getMessage()]))
+            ->expireSessionUsing(fn () => back()->with([
+                'error' => 'Your session has expired. Please refresh the page.',
+            ])),
+    );
+
+    Route::get('/419', fn () => throw new TokenMismatchException('CSRF token mismatch.'));
+
+    get('419', ['referer' => '/previous'])
+        ->assertRedirect('/previous')
+        ->assertSessionHas('error');
+});
+
+test('exceptions are not rendered when outside of the specified environments', function () {
+    register_handler(
+        HandleHybridExceptions::register()
+            ->inEnvironments('production')
+            ->renderUsing(fn (Response $response) => view('error', [
+                'status' => $response->getStatusCode(),
+            ])),
+    );
+
+    Route::get('/404', fn () => throw new NotFoundHttpException());
+
+    get('404')
+        ->assertNotHybrid()
+        ->assertNotFound();
+});
+
+test('only the specified status codes are handled', function () {
+    register_handler(
+        HandleHybridExceptions::register()
+            ->inEnvironments('testing')
+            ->handleStatusCodes(404)
+            ->renderUsing(fn (Response $response) => view('error', [
+                'status' => $response->getStatusCode(),
+            ])),
+    );
+
+    Route::get('/500', fn () => throw new \Exception());
+
+    get('500')
+        ->assertNotHybrid()
+        ->assertStatus(500);
+});


### PR DESCRIPTION
This pull request improves the DX for the new exception handling API introduced in Laravel 11:

```php
use Hybridly\Exceptions\HandleHybridExceptions;

return Application::configure(basePath: dirname(__DIR__))
    // ...
    ->withExceptions(
        HandleHybridExceptions::register()
            ->renderUsing(fn (Response $response) => view('error', [
                'status' => $response->getStatusCode()
            ]))
            ->expireSessionUsing(fn () => back()->with([ // [!code focus:3]
                'error' => 'Your session has expired. Please refresh the page.',
            ]))
    )
    ->create();
```