### PR TITLE
feat(vite): support ddev and lando environments

### DIFF
--- a/packages/vite/src/config/env.ts
+++ b/packages/vite/src/config/env.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs'
+import { loadEnv } from 'vite'
+
+export function getEnv() {
+	return { ...process.env, ...loadEnv('mock', process.cwd(), '') }
+}
+
+let phpExecutable = null
+
+export function getPhpExecutable(): string[] {
+	if (phpExecutable) {
+		return phpExecutable
+	}
+
+	const env = getEnv()
+
+	const php = (env.PHP_EXECUTABLE_PATH ?? 'php').split(' ')
+
+	if (!env.PHP_EXECUTABLE_PATH) {
+		const devEnvironment = determineDevEnvironment()
+
+		if (devEnvironment === 'ddev') {
+			php.unshift('ddev')
+		} else if (devEnvironment === 'lando') {
+			php.unshift('lando')
+		}
+	}
+
+	return phpExecutable = php
+}
+
+let devEnvironment = null
+
+export function determineDevEnvironment() {
+	if (devEnvironment !== null) {
+		return devEnvironment
+	}
+
+	devEnvironment = ''
+
+	if (fs.existsSync(`${process.cwd()}/.ddev`)) {
+		devEnvironment = 'ddev'
+	} else if (fs.existsSync(`${process.cwd()}/.lando.yml`)) {
+		devEnvironment = 'lando'
+	}
+
+	return devEnvironment
+}

--- a/packages/vite/src/config/load.ts
+++ b/packages/vite/src/config/load.ts
@@ -1,21 +1,18 @@
-import { exec } from 'node:child_process'
-import { promisify } from 'node:util'
 import type { DynamicConfiguration } from '@hybridly/core'
+import { execSync } from '../utils'
 import { determineDevEnvironment, getPhpExecutable } from './env'
-
-const execSync = promisify(exec)
 
 export async function loadConfiguration(): Promise<DynamicConfiguration> {
 	try {
-		const php = getPhpExecutable().join(' ')
+		const php = (await getPhpExecutable()).join(' ')
 		const { stdout } = await execSync(`${php} artisan hybridly:config`)
 		return JSON.parse(stdout)
 	} catch (e) {
 		console.error('Could not load configuration from [php artisan hybridly:config].')
 
-		if (determineDevEnvironment() === 'ddev') {
+		if (await determineDevEnvironment() === 'ddev') {
 			console.error('This is possibly caused by not starting ddev first.')
-		} else if (determineDevEnvironment() === 'lando') {
+		} else if (await determineDevEnvironment() === 'lando') {
 			console.error('This is possibly caused by not starting lando first.')
 		}
 

--- a/packages/vite/src/config/load.ts
+++ b/packages/vite/src/config/load.ts
@@ -1,18 +1,24 @@
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { DynamicConfiguration } from '@hybridly/core'
-import { loadEnv } from 'vite'
+import { determineDevEnvironment, getPhpExecutable } from './env'
 
 const execSync = promisify(exec)
 
 export async function loadConfiguration(): Promise<DynamicConfiguration> {
 	try {
-		const env = { ...process.env, ...loadEnv('mock', process.cwd(), '') }
-		const php = env.PHP_EXECUTABLE_PATH ?? 'php'
+		const php = getPhpExecutable().join(' ')
 		const { stdout } = await execSync(`${php} artisan hybridly:config`)
 		return JSON.parse(stdout)
 	} catch (e) {
-		console.error('Could not load configuration from [php artisan].')
+		console.error('Could not load configuration from [php artisan hybridly:config].')
+
+		if (determineDevEnvironment() === 'ddev') {
+			console.error('This is possibly caused by not starting ddev first.')
+		} else if (determineDevEnvironment() === 'lando') {
+			console.error('This is possibly caused by not starting lando first.')
+		}
+
 		throw e
 	}
 }

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -24,7 +24,7 @@ export default async function plugin(options: Options = {}) {
 		initialize(resolvedOptions, config),
 		layout(resolvedOptions, config),
 		resolvedOptions.laravel !== false && laravel(resolvedOptions, config),
-		resolvedOptions.run !== false && run(getRunOptions(resolvedOptions)),
+		resolvedOptions.run !== false && run(await getRunOptions(resolvedOptions)),
 		resolvedOptions.vueComponents !== false && vueComponents(await getVueComponentsOptions(resolvedOptions, config)),
 		resolvedOptions.autoImports !== false && autoimport(getAutoImportsOptions(resolvedOptions, config)),
 		resolvedOptions.icons !== false && icons(getIconsOptions(resolvedOptions, config)),

--- a/packages/vite/src/integrations/run.ts
+++ b/packages/vite/src/integrations/run.ts
@@ -3,12 +3,13 @@ import type { Runner } from 'vite-plugin-run'
 import type { ViteOptions } from '../types'
 import { getPhpExecutable } from '../config/env'
 
-function getRunOptions(options: ViteOptions): Runner[] {
+async function getRunOptions(options: ViteOptions): Promise<Runner[]> {
 	if (options.run === false) {
 		return []
 	}
 
-	const php = getPhpExecutable()
+	// Explicit typing is needed to please TypeScript
+	const php: string[] = await getPhpExecutable()
 
 	return [
 		{

--- a/packages/vite/src/integrations/run.ts
+++ b/packages/vite/src/integrations/run.ts
@@ -1,18 +1,19 @@
 import run from 'vite-plugin-run'
 import type { Runner } from 'vite-plugin-run'
 import type { ViteOptions } from '../types'
+import { getPhpExecutable } from '../config/env'
 
 function getRunOptions(options: ViteOptions): Runner[] {
 	if (options.run === false) {
 		return []
 	}
 
-	const php = process.env.PHP_EXECUTABLE_PATH ?? 'php'
+	const php = getPhpExecutable()
 
 	return [
 		{
 			name: 'Generate TypeScript types',
-			run: [php, 'artisan', 'hybridly:types', (options.allowTypeGenerationFailures !== false) ? '--allow-failures' : ''].filter(Boolean),
+			run: [...php, 'artisan', 'hybridly:types', (options.allowTypeGenerationFailures !== false) ? '--allow-failures' : ''].filter(Boolean),
 			pattern: [
 				'+(app|src)/**/*Data.php',
 				'+(app|src)/**/Enums/*.php',
@@ -21,7 +22,7 @@ function getRunOptions(options: ViteOptions): Runner[] {
 		},
 		{
 			name: 'Generate i18n',
-			run: [php, 'artisan', 'hybridly:i18n'],
+			run: [...php, 'artisan', 'hybridly:i18n'],
 			pattern: 'lang/**/*.php',
 		},
 		...options.run ?? [],

--- a/packages/vite/src/laravel/index.ts
+++ b/packages/vite/src/laravel/index.ts
@@ -80,7 +80,7 @@ export default function laravel(options: ViteOptions, hybridlyConfig: DynamicCon
 			const envDir = resolvedConfig.envDir || process.cwd()
 			const appUrl = loadEnv(resolvedConfig.mode, envDir, 'APP_URL').APP_URL ?? 'undefined'
 
-			server.httpServer?.once('listening', () => {
+			server.httpServer?.once('listening', async() => {
 				const address = server.httpServer?.address()
 				const isAddressInfo = (x: string | AddressInfo | null | undefined): x is AddressInfo => typeof x === 'object'
 
@@ -103,7 +103,7 @@ export default function laravel(options: ViteOptions, hybridlyConfig: DynamicCon
 					version += `${colors.yellow(`v${hybridlyConfig.versions.npm}`)} ${colors.dim('(npm)')}`
 					version += ` — ${colors.yellow('this may lead to undefined behavior')}`
 
-					const devEnvironment = determineDevEnvironment()
+					const devEnvironment = await determineDevEnvironment()
 
 					setTimeout(() => {
 						server.config.logger.info(`\n  ${colors.magenta(`${colors.bold('HYBRIDLY')} v${hybridlyConfig.versions.composer}`)}  ${latest}`)
@@ -111,8 +111,8 @@ export default function laravel(options: ViteOptions, hybridlyConfig: DynamicCon
 						server.config.logger.info(`  ${colors.green('➜')}  ${colors.bold('URL')}: ${colors.cyan(hybridlyConfig.routing.url)}`)
 						server.config.logger.info(`  ${colors.green('➜')}  ${colors.bold('Registered')}: ${registered}`)
 
-						if (devEnvironment) {
-							server.config.logger.info(`  ${colors.green('➜')}  ${colors.bold('Detected dev environment')}: ${devEnvironment}`)
+						if (devEnvironment !== 'native') {
+							server.config.logger.info(`  ${colors.green('➜')}  ${colors.bold('Development environment')}: ${colors.cyan(devEnvironment)}`)
 						}
 
 						if (hybridlyConfig.versions.composer !== hybridlyConfig.versions.npm) {

--- a/packages/vite/src/laravel/index.ts
+++ b/packages/vite/src/laravel/index.ts
@@ -7,6 +7,7 @@ import { loadEnv } from 'vite'
 import type { DynamicConfiguration } from '@hybridly/core'
 import type { InputOption } from 'rollup'
 import type { ViteOptions } from '../types'
+import { determineDevEnvironment } from '../config/env'
 import { isIpv6 } from './utils'
 import { resolveDevelopmentEnvironmentServerConfig, resolveEnvironmentServerConfig } from './dev-env'
 
@@ -102,11 +103,17 @@ export default function laravel(options: ViteOptions, hybridlyConfig: DynamicCon
 					version += `${colors.yellow(`v${hybridlyConfig.versions.npm}`)} ${colors.dim('(npm)')}`
 					version += ` — ${colors.yellow('this may lead to undefined behavior')}`
 
+					const devEnvironment = determineDevEnvironment()
+
 					setTimeout(() => {
 						server.config.logger.info(`\n  ${colors.magenta(`${colors.bold('HYBRIDLY')} v${hybridlyConfig.versions.composer}`)}  ${latest}`)
 						server.config.logger.info('')
 						server.config.logger.info(`  ${colors.green('➜')}  ${colors.bold('URL')}: ${colors.cyan(hybridlyConfig.routing.url)}`)
 						server.config.logger.info(`  ${colors.green('➜')}  ${colors.bold('Registered')}: ${registered}`)
+
+						if (devEnvironment) {
+							server.config.logger.info(`  ${colors.green('➜')}  ${colors.bold('Detected dev environment')}: ${devEnvironment}`)
+						}
 
 						if (hybridlyConfig.versions.composer !== hybridlyConfig.versions.npm) {
 							server.config.logger.info(`  ${colors.yellow('➜')}  ${colors.bold('Version mismatch')}: ${version}`)

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -1,6 +1,10 @@
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
 import makeDebugger from 'debug'
 import { importModule, isPackageExists, resolveModule } from 'local-pkg'
 import { LAYOUT_PLUGIN_NAME, CONFIG_PLUGIN_NAME } from './constants'
+
+export const execSync = promisify(exec)
 
 export const debug = {
 	config: makeDebugger(CONFIG_PLUGIN_NAME),


### PR DESCRIPTION
With this PR the Vite plugin will detect a `.ddev` folder or a `.lando.yml` file and set a prefix to the php executable unless `PHP_EXECUTABLE_PATH` is set. 

Includes some extra messages when an error occurs during `php artisan hybridly:config` because running Vite without starting ddev/lando first will add a lot of extra messages to the output of the command and cause an error to happen on startup.

Also includes `Detected dev environment: ddev` in the console output below `Registered` and above `Version mismatch` to indicate what environment was found. This is to clarify to the developer that it's not using the default php path and hopefully prevent confusion.

Technically this could break some environments for people if they don't use ddev/lando but do have the folder/file in the project, but this is very unusual as these should not exist in the project if a developer is not using them.