### PR TITLE
feat: useResource

### DIFF
--- a/packages/laravel/src/Hybridly.php
+++ b/packages/laravel/src/Hybridly.php
@@ -16,6 +16,7 @@ final class Hybridly
     use Concerns\HasSharedProperties;
     use Concerns\HasVersion;
     use Concerns\ResolvesUrls;
+    use Resources\Concerns\HasResources;
     use Conditionable;
     use ForwardsCalls, Macroable {
         Macroable::__call as macroCall;

--- a/packages/laravel/src/HybridlyServiceProvider.php
+++ b/packages/laravel/src/HybridlyServiceProvider.php
@@ -10,6 +10,7 @@ use Hybridly\Commands\InstallCommand;
 use Hybridly\Commands\MakeTableCommand;
 use Hybridly\Commands\PrintConfigurationCommand;
 use Hybridly\Http\Controller;
+use Hybridly\Resources\Http\ServeResourceController;
 use Hybridly\Support\Configuration\Configuration;
 use Hybridly\Support\Data\PartialLazy;
 use Hybridly\Support\RayDumper;
@@ -204,6 +205,10 @@ class HybridlyServiceProvider extends PackageServiceProvider
             Route::post($this->getConfiguration()->tables->actionsEndpoint, InvokedActionController::class)
                 ->middleware($this->getConfiguration()->tables->actionsEndpointMiddleware)
                 ->name($this->getConfiguration()->tables->actionsEndpointName);
+
+            Route::post('/hybridly/resource', ServeResourceController::class)
+                ->middleware('web')
+                ->name('hybridly.resource');
         }
     }
 

--- a/packages/laravel/src/Resources/Concerns/HasResources.php
+++ b/packages/laravel/src/Resources/Concerns/HasResources.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Hybridly\Resources\Concerns;
+
+use Exception;
+
+trait HasResources
+{
+    /** @var array<string, callable> */
+    protected array $registeredResources = [];
+
+    public function registerResource(string $key, callable $callback): void
+    {
+        $this->registeredResources[$key] = $callback;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getResource(string $key): mixed
+    {
+        if (!$this->hasResource($key)) {
+            throw new Exception('Resource does not exist');
+        }
+
+        return $this->registeredResources[$key]();
+    }
+
+    public function hasResource(string $key): bool
+    {
+        return isset($this->registeredResources[$key]);
+    }
+}

--- a/packages/laravel/src/Resources/Http/ServeResourceController.php
+++ b/packages/laravel/src/Resources/Http/ServeResourceController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Hybridly\Resources\Http;
+
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+
+class ServeResourceController
+{
+    /**
+     * @throws Exception
+     */
+    public function __invoke(Request $request)
+    {
+        $payload = $request->json();
+        $resources = [];
+
+        $keys = $payload->all('keys');
+
+        foreach ($keys as $key) {
+            $resources[$key] = hybridly()->getResource($key);
+        }
+
+        if ($route = $payload->get('route')) {
+            Cache::set('hybridly.resources.routes.' . $route, $keys, 3600);
+        }
+
+        return json_encode($resources);
+    }
+}

--- a/packages/laravel/src/Resources/Http/ServeResourcesMiddleware.php
+++ b/packages/laravel/src/Resources/Http/ServeResourcesMiddleware.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Hybridly\Resources\Http;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+
+class ServeResourcesMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $routeName = $request->route()->getName();
+
+        $resourceKeys = Cache::get('hybridly.resources.routes.' . $routeName);
+        if($resourceKeys) {
+            $hybridly = hybridly();
+            $resources = [];
+
+            foreach ($resourceKeys as $resourceKey) {
+                if(!$hybridly->hasResource($resourceKey)) {
+                    continue;
+                }
+
+                $resources[$resourceKey] = $hybridly->getResource($resourceKey);
+            }
+
+            $hybridly->share('resources', $resources);
+        }
+
+        return $next($request);
+    }
+}

--- a/packages/vue/src/composables/resource.ts
+++ b/packages/vue/src/composables/resource.ts
@@ -1,0 +1,59 @@
+import axios from "axios";
+import {Ref} from "vue";
+import {state} from "../stores/state";
+
+let queued = {};
+let refs = {};
+
+let queueTimeout = null;
+
+export function useResource<T>(key: string, placeholder: T): Ref<T> {
+	if (refs.hasOwnProperty(key)) {
+		return refs[key];
+	}
+
+	const resource = ref<T>(placeholder);
+
+	queued[key] = refs[key] = resource;
+	initiateResolve();
+
+	return resource;
+}
+
+function initiateResolve() {
+	if (queueTimeout) {
+		return;
+	}
+
+	queueTimeout = setTimeout(() => {
+		queueTimeout = null;
+		resolveResources();
+	}, 50);
+}
+
+async function resolveResources() {
+	const keys = Object.keys(queued);
+	queued = {};
+
+	const response = await axios.post(route('hybridly.resource'), {
+		keys: keys,
+		route: router.current()
+	});
+
+	for (const [key, value] of Object.entries(response.data)) {
+		refs[key].value = value;
+	}
+}
+
+export function initResources() {
+	queued = {};
+	refs = {};
+	queueTimeout = null;
+
+	if (state.properties?.resources) {
+		for (const [key, value] of Object.entries(state.properties?.resources)) {
+			refs[key] = ref(value);
+		}
+	}
+}
+

--- a/packages/vue/src/initialize.ts
+++ b/packages/vue/src/initialize.ts
@@ -11,6 +11,7 @@ import { devtools } from './devtools'
 import { dialogStore } from './stores/dialog'
 import { onMountedCallbacks } from './stores/mount'
 import { viewTransition } from './plugins/view-transition'
+import {initResources} from "./composables/resource";
 
 /**
  * Initializes Hybridly's router and context.
@@ -39,6 +40,7 @@ export async function initializeHybridly(options: InitializeOptions = {}) {
 			},
 			onContextUpdate: (context) => {
 				state.setContext(context)
+				initResources()
 			},
 			onViewSwap: async(options) => {
 				if (options.component) {


### PR DESCRIPTION
I created a rough proof of concept for my `useResource` idea, this name is not final of course I just think it fits well. 

Under the hood it's basically an API endpoint that fetches simple data, this means it doesn't accept parameters by design. It then caches what route name the the resource was requested on and uses that data to preemptively get that resource and pass it to the Hybridly frontend.

Some changes that need to be made are probably the way they're cached, maybe it's possible to build a smarter solution, and there should be a way to fetch resources without it remembering in case a resource is expensive to request or the resource is not always used on the page.

Typescript is also not implemented yet as I'm not experienced enough with both Typescript definitions and `typescript-transformer`. My idea for this however, was to use docblocks as seen below.

```php
/** @return UserData[] */
hybridly()->registerResource('users', function() {
    return UserData::collect(User::all());
});
```

`useResource` returns a ref with the given default and gets updated as soon as the resource has resolved, this is instant when resource was cached on the route.

```ts
const users = useResource('users', []);
```

There are likely many things wrong with my integration into Hybridly and Typescript will probably whine at a lot of things but I thought I'd first show off the idea before spending too much time on it!