### PR TITLE
docs: include reference to agednerd/hybridly-breeze-app

### DIFF
--- a/docs/guide/demonstration.md
+++ b/docs/guide/demonstration.md
@@ -56,4 +56,5 @@ The following recording is a small preview of the features of Blue Bird. Example
 ## Community projects
 
 [PingCRM](https://github.com/inertiajs/pingcrm), Inertia's demonstration project, has been migrated to Hybridly by [Amine Ilidrissi](https://twitter.com/realaminevg). You may check out the repository [here](https://github.com/hybridly/pingcrm).
+
 [Hybridly Laravel Breeze Scaffold](https://github.com/agednerd/hybridly-breeze-app), Laravel Breeze's base Vue scaffold has been migrated to Hybridly by [William Lepinski](https://github.com/wlepinski). You may check out the repository [here](https://github.com/agednerd/hybridly-breeze-app).

--- a/docs/guide/demonstration.md
+++ b/docs/guide/demonstration.md
@@ -56,3 +56,4 @@ The following recording is a small preview of the features of Blue Bird. Example
 ## Community projects
 
 [PingCRM](https://github.com/inertiajs/pingcrm), Inertia's demonstration project, has been migrated to Hybridly by [Amine Ilidrissi](https://twitter.com/realaminevg). You may check out the repository [here](https://github.com/hybridly/pingcrm).
+[Hybridly Laravel Breeze Scaffold](https://github.com/agednerd/hybridly-breeze-app), Laravel Breeze's base Vue scaffold has been migrated to Hybridly by [William Lepinski](https://github.com/wlepinski). You may check out the repository [here](https://github.com/agednerd/hybridly-breeze-app).


### PR DESCRIPTION
- Include reference to the migrated Vue scaffold code for laravel/breeze.

The repository include all the same features a scaffold of [Laravel Breeze with Inertia / Vue](https://laravel.com/docs/11.x/starter-kits#breeze-and-inertia) would give you but I took the time to migrate all components and pages to work with Hybridly.