### PR TITLE
fix(dialogs): exclude shared properties from dialog properties

### DIFF
--- a/packages/laravel/src/View/Factory.php
+++ b/packages/laravel/src/View/Factory.php
@@ -282,7 +282,7 @@ class Factory implements HybridResponse
     /**
      * Resolves the properties on the given view or dialog.
      */
-    protected function resolveProperties(Dialog|View $view, Request $request, boolean $includeSharedProperties = true): array
+    protected function resolveProperties(Dialog|View $view, Request $request, bool $includeSharedProperties = true): array
     {
         // We don't use dependency injection, because the request object
         // could be different than the one given to `toResponse`.

--- a/packages/laravel/src/View/Factory.php
+++ b/packages/laravel/src/View/Factory.php
@@ -176,7 +176,7 @@ class Factory implements HybridResponse
 
     protected function renderDialog(Request $request, Payload $payload)
     {
-        [$properties] = $this->resolveProperties($payload->dialog, $request);
+        [$properties] = $this->resolveProperties($payload->dialog, $request, false);
 
         return new Payload(
             view: $this->getBaseView(
@@ -282,7 +282,7 @@ class Factory implements HybridResponse
     /**
      * Resolves the properties on the given view or dialog.
      */
-    protected function resolveProperties(Dialog|View $view, Request $request): array
+    protected function resolveProperties(Dialog|View $view, Request $request, boolean $includeSharedProperties = true): array
     {
         // We don't use dependency injection, because the request object
         // could be different than the one given to `toResponse`.
@@ -290,7 +290,7 @@ class Factory implements HybridResponse
 
         return $resolver->resolve(
             component: $view->component,
-            properties: [...$this->hybridly->shared(), ...$view->properties],
+            properties: $includeSharedProperties ? [...$this->hybridly->shared(), ...$view->properties] : $view->properties,
             persisted: $this->hybridly->persisted(),
         );
     }

--- a/packages/laravel/src/View/Factory.php
+++ b/packages/laravel/src/View/Factory.php
@@ -176,7 +176,13 @@ class Factory implements HybridResponse
 
     protected function renderDialog(Request $request, Payload $payload)
     {
-        [$properties] = $this->resolveProperties($payload->dialog, $request, false);
+        // Dialogs do not need shared properties, as they are already part of the base view.
+        // See: https://github.com/hybridly/hybridly/pull/153
+        [$properties] = $this->resolveProperties(
+            view: $payload->dialog,
+            request: $request,
+            includeSharedProperties: false,
+        );
 
         return new Payload(
             view: $this->getBaseView(

--- a/packages/laravel/tests/Laravel/View/FactoryTest.php
+++ b/packages/laravel/tests/Laravel/View/FactoryTest.php
@@ -185,6 +185,8 @@ test('properties can be added on-the-fly on the factory instance', function () {
 test('dialogs and their properties can be resolved', function () {
     Route::get('/', fn () => hybridly('index', ['foo' => 'bar']))->name('index');
 
+    hybridly()->share(['shared' => 'data']);
+
     $request = mock_request(url: '/users/makise', hybridly: true, bind: true);
     $factory = hybridly('users.edit', [
         'user' => 'Makise Kurisu',
@@ -201,6 +203,7 @@ test('dialogs and their properties can be resolved', function () {
             'component' => 'index',
             'properties' => [
                 'foo' => 'bar',
+                'shared' => 'data',
             ],
             'deferred' => [],
         ],


### PR DESCRIPTION
This PR changes dialog properties to only include the properties specified in the controller. The shared properties will still be returned as part of the `base` properties (unless explicitly excluded). 

## Problem this solves

Right now when a dialog is rendered, all of the shared properties are sent to the frontend twice: once via the base properties and once via the dialog's properties. This can potentially be a lot of data that is unnecessarily sent to the frontend.

In addition, if I want to render a dialog using `only`, the excluding properties are still returned via the dialog's properties. You could argue this is a second problem that should also be solved.

Before:

<img width="155" alt="Screenshot 2024-06-13 at 10 30 38" src="https://github.com/hybridly/hybridly/assets/791222/9008857f-ac94-43d9-9c1d-b9cab0bd8ec9">

After:

<img width="142" alt="Screenshot 2024-06-13 at 10 29 46" src="https://github.com/hybridly/hybridly/assets/791222/823acbc6-51f2-42cf-aa7d-9f6921a44a8a">