### PR TITLE
feat(dialog): allow `show` to be used as v-model

### DIFF
--- a/packages/vue/src/composables/dialog.ts
+++ b/packages/vue/src/composables/dialog.ts
@@ -15,7 +15,7 @@ export function useDialog() {
 		/** Unmounts the dialog. Should be called after its closing animations. */
 		unmount: () => dialogStore.removeComponent(),
 		/** Whether the dialog is shown. */
-		show: computed(() => dialogStore.state.show.value),
+		show: computed({ get: () => dialogStore.state.show.value, set: (v) => !v ? router.dialog.close({ local: true }) : null }),
 		/** Properties of the dialog. */
 		properties: computed(() => state.context.value?.dialog?.properties),
 	}


### PR DESCRIPTION
By using a computed setter we can make the `show` of the dialog usable as a model value