### PR TITLE
fix(table): correct `isPageSelected` logic

### DIFF
--- a/packages/vue/src/composables/table.ts
+++ b/packages/vue/src/composables/table.ts
@@ -166,7 +166,7 @@ export function useTable<
 		/** Deselects records on the current page. */
 		deselectPage: () => bulk.deselect(...table.value.records.map((record: RecordType) => getRecordKey(record))),
 		/** Whether all records on the current page are selected. */
-		isPageSelected: computed(() => table.value.records.every((record: RecordType) => bulk.selected(getRecordKey(record)))),
+		isPageSelected: computed(() => table.value.records.length > 0 && table.value.records.every((record: RecordType) => bulk.selected(getRecordKey(record)))),
 		/** Checks if the given record is selected. */
 		isSelected: (record: RecordType) => bulk.selected(getRecordKey(record)),
 		/** Whether all records are selected. */


### PR DESCRIPTION
fix(table): prevent 'isPageSelected' from returning true when no recordsEnsure that 'isPageSelected' computed property correctly handles the case
where there are no records in the table. It now returns false instead of
potentially evaluating to true due to the empty array every() call returning
true. This change aligns the behavior with the expected logic.