### PR TITLE
docs: correct viewmodel name in example

### DIFF
--- a/docs/guide/responses.md
+++ b/docs/guide/responses.md
@@ -139,7 +139,7 @@ class ChirpViewModel extends Data
     public function __construct(
         public readonly ChirpData $chirp,
         #[DataCollectionOf(ChirpData::class)]
-        public readonly PaginatedDataCollection $chirps,
+        public readonly PaginatedDataCollection $comments,
         public readonly string $previous,
     ) {
     }


### PR DESCRIPTION
change name of the public property $chirps to $comments base on the example below