### PR TITLE
Improvement for Preloading on touch devices

### DIFF
--- a/packages/vue/src/components/link.ts
+++ b/packages/vue/src/components/link.ts
@@ -56,7 +56,7 @@ export const RouterLink = defineComponent({
 					return
 				}
 
-				if (type === 'mount' && preloads !== 'mount') {
+				if (type === 'mount' && preloads !== 'mount' && !('ontouchstart' in window || navigator.maxTouchPoints > 0)) {
 					return
 				}
 


### PR DESCRIPTION
When using the preloading feature with links, the default behavior is that the site is being preloaded on hover. On a touch device this is not possible so with this PR it will preload on mount if preloading is enabled in hover mode.

This is slightly opinionated as a lot of things in hybridly but I think it would improve the developer experience as it's a pretty default behavior you would want to have when you use preloading, to not break your site on mobile.