### PR TITLE
fix(tables): make record id accessible internally

### DIFF
--- a/packages/vue/src/composables/table.ts
+++ b/packages/vue/src/composables/table.ts
@@ -93,7 +93,7 @@ export function useTable<
 		}
 
 		if (Reflect.has(record, '__hybridId')) {
-			return Reflect.get(record, '__hybridId').value as any
+			return Reflect.get(record, '__hybridId') as any
 		}
 
 		return Reflect.get(record, table.value.keyName).value as any


### PR DESCRIPTION
The backend does not wrap the `__hybridId` attribute:

```php
// These are special columns that shouldn't be nested as a {value, extra} object.
if (\in_array($key, ['__hybridId', 'authorization'], strict: true)) {
    return [$key => $value];
}
```

<img width="432" alt="Screenshot 2024-07-25 at 12 22 40" src="https://github.com/user-attachments/assets/b615b276-3b4b-4684-a05d-cd6f1bd9d42b">

So we don't need to use `.value` when accessing it.