### PR TITLE
fix(types): change `previous_*` to `prev_*` for `CursorPaginatorMeta`

### DIFF
--- a/packages/vue/src/composables/paginator.ts
+++ b/packages/vue/src/composables/paginator.ts
@@ -41,10 +41,10 @@ interface PaginatorLink {
 interface CursorPaginatorMeta {
 	path: string
 	per_page: number
-	previous_cursor: string
+	prev_cursor: string
 	next_cursor: string
 	next_page_url?: string
-	previous_page_url?: string
+	prev_page_url?: string
 }
 
 interface SimplePaginatorMeta {


### PR DESCRIPTION
I am working on an application using Hybridly, and I was having trouble using the `CursorPaginator<T>` type provided for taking in cursor paginators as a prop.

My issue is that in its current form, `CursorPaginatorMeta` provides the previous page as `previous_page_url` when [according to the Laravel documentation](https://laravel.com/docs/11.x/pagination#converting-results-to-json), paginators give the field as `prev_page_url` and `prev_cursor`.

With this fix, the `CursorPaginator<T>` would be using the correct fields.