### PR TITLE
fix(components): add `scope` variable to `HasScope` concern

### DIFF
--- a/packages/laravel/src/Components/Concerns/HasScope.php
+++ b/packages/laravel/src/Components/Concerns/HasScope.php
@@ -4,6 +4,8 @@ namespace Hybridly\Components\Concerns;
 
 trait HasScope
 {
+    private null|\Closure|string $scope;
+
     public function scope(null|\Closure|string $scope): static
     {
         $this->scope = $scope;

--- a/packages/laravel/src/Components/Concerns/HasScope.php
+++ b/packages/laravel/src/Components/Concerns/HasScope.php
@@ -4,7 +4,7 @@ namespace Hybridly\Components\Concerns;
 
 trait HasScope
 {
-    private null|\Closure|string $scope;
+    protected null|\Closure|string $scope;
 
     public function scope(null|\Closure|string $scope): static
     {

--- a/packages/laravel/tests/Laravel/Tables/Fixtures/BasicScopedProductsTable.php
+++ b/packages/laravel/tests/Laravel/Tables/Fixtures/BasicScopedProductsTable.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Collection;
 class BasicScopedProductsTable extends Table
 {
     protected string $model = Product::class;
-    protected string $scope = 'custom-scope';
+    protected null|\Closure|string $scope = 'custom-scope';
 
     public function defineRefiners(): array
     {


### PR DESCRIPTION
Fix deprecation warnings for:
```
Creation of dynamic property Hybridly\\Refining\\Refine::$scope is deprecated in /vendor/hybridly/laravel/src/Components/Concerns/HasScope.php on line 9
```