### PR TITLE
feat(configuration): allow route extractor to be overridden

### DIFF
--- a/packages/laravel/src/Commands/PrintConfigurationCommand.php
+++ b/packages/laravel/src/Commands/PrintConfigurationCommand.php
@@ -4,7 +4,6 @@ namespace Hybridly\Commands;
 
 use Hybridly\Hybridly;
 use Hybridly\Support\Configuration\Configuration;
-use Hybridly\Support\RouteExtractor;
 use Hybridly\Support\Version;
 use Illuminate\Console\Command;
 
@@ -14,8 +13,10 @@ class PrintConfigurationCommand extends Command
     protected $description = 'Prints the internal Hybridly configuration.';
     protected $hidden = true;
 
-    public function handle(Hybridly $hybridly, RouteExtractor $routeExtractor): int
+    public function handle(Hybridly $hybridly): int
     {
+        $routeExtractor = $this->laravel->make(Configuration::get()->router->routesExtractor);
+
         $configuration = [
             'versions' => [
                 'composer' => Version::getComposerVersion(),

--- a/packages/laravel/src/Support/Configuration/Router.php
+++ b/packages/laravel/src/Support/Configuration/Router.php
@@ -2,11 +2,14 @@
 
 namespace Hybridly\Support\Configuration;
 
+use Hybridly\Support\RouteExtractor;
+
 final class Router
 {
     public function __construct(
         public array $allowedVendors,
         public array $excludedRoutes,
+        public string $routesExtractor,
     ) {
     }
 
@@ -17,6 +20,7 @@ final class Router
                 'laravel/fortify',
             ],
             excludedRoutes: $config['exclude'] ?? [],
+            routesExtractor: $config['routes_extractor'] ?? RouteExtractor::class,
         );
     }
 }

--- a/packages/laravel/src/Support/RouteExtractor.php
+++ b/packages/laravel/src/Support/RouteExtractor.php
@@ -13,7 +13,7 @@ use JsonSerializable;
 use ReflectionClass;
 use ReflectionMethod;
 
-final class RouteExtractor implements JsonSerializable, Arrayable
+class RouteExtractor implements JsonSerializable, Arrayable
 {
     public function __construct(
         private readonly Router $router,


### PR DESCRIPTION
Closes #189

This pull request adds the ability to replace the `RouteExtractor`, which exposes routes to the front-end.

```php
// config/hybridly.php

'router' => [
    'routes_extractor' => CustomRouteExtractor::class, // <-- add this
    'allowed_vendors' => [],
    'exclude' => [],
]
```