### PR TITLE
fix(routing): generate query arguments with optional parameters

### DIFF
--- a/packages/core/src/routing/route.ts
+++ b/packages/core/src/routing/route.ts
@@ -170,9 +170,11 @@ function getRouteTransformable(routeName: string, routeParameters?: any, shouldT
 	const replaceParameter = (match: string, parameterName: string, optional: string | null) => {
 		const value = getRouteParameterValue(routeName, parameterName, parameters)
 
+		const found = missing.indexOf(parameterName)
 		// Removes this parameter from the missing parameter list.
-		missing.splice(missing.indexOf(parameterName), 1)
-
+		if (found >= 0) {
+			missing.splice(found, 1)
+		}
 		// If the parameter is passed, use it.
 		if (value) {
 			return value

--- a/packages/core/test/routing/route.test.ts
+++ b/packages/core/test/routing/route.test.ts
@@ -77,4 +77,24 @@ describe('an url can be generated from a route name', () => {
 		const bar = { id: 'owo' }
 		expect(route('foo', { bar })).toBe('https://bluebird.test/owo')
 	})
+
+	it('foo', async () => {
+		await initializeContext(makeRouterContextOptions({
+			routing: {
+				url: 'https://bluebird.test',
+				defaults: {
+					bar: 'baz',
+				},
+				routes: {
+					test: {
+						method: ['GET'],
+						uri: 'test/{page?}',
+						name: 'test',
+					},
+				},
+			},
+		}))
+
+		expect(route('test', { foo: 'bar', baz: 'baz' })).toBe('https://bluebird.test/test?foo=bar&baz=baz')
+	})
 })


### PR DESCRIPTION
Given any route with an optional parameter

Eg php
```php
Route::get('test/{page?}')->name('test')
```

The `route` util would remove query args

Eg query arg `foo` is missing in the following
```js
route('test', {foo: 'bar', 'baz': 'baz'}) // /test?baz=baz
// expected /test?foo=bar&baz=baz
```

This is what currently happens
```
const missing = ['categories'];
missing.splice(missing.indexOf('page'), 1)
console.log(missing) // []
```