### PR TITLE
refactor: fix php 8.4 deprecations

### DIFF
--- a/packages/laravel/src/Commands/I18nCommand.php
+++ b/packages/laravel/src/Commands/I18nCommand.php
@@ -86,7 +86,7 @@ class I18nCommand extends Command
     /**
      * Gets the translations as an array.
      */
-    protected function getTranslations(string $lang = null): array
+    protected function getTranslations(?string $lang = null): array
     {
         $translations = $this->makeFolderFilesTree($this->getLangPath());
 
@@ -100,7 +100,7 @@ class I18nCommand extends Command
     /**
      * Gets the translations as an JSON-encoded string.
      */
-    protected function getTranslationsAsJson(string $lang = null): string
+    protected function getTranslationsAsJson(?string $lang = null): string
     {
         return str(json_encode($this->getTranslations($lang)))
             ->replaceMatches('/:(\w+)/', '{${1}}')
@@ -135,7 +135,7 @@ class I18nCommand extends Command
     /**
      * Gets the path for the given locale.
      */
-    protected function getLocalePath(string $locale = null): string
+    protected function getLocalePath(?string $locale = null): string
     {
         return implode(\DIRECTORY_SEPARATOR, [
             $this->getLocalesPath(),
@@ -194,7 +194,7 @@ class I18nCommand extends Command
         return $result;
     }
 
-    protected function writeSuccess(string $path, string $locale = null): void
+    protected function writeSuccess(string $path, ?string $locale = null): void
     {
         $this->components->info(
             \sprintf(

--- a/packages/laravel/src/Concerns/ForwardsToHybridlyHelpers.php
+++ b/packages/laravel/src/Concerns/ForwardsToHybridlyHelpers.php
@@ -26,7 +26,7 @@ trait ForwardsToHybridlyHelpers
      *
      * @see https://hybridly.dev/api/laravel/hybridly.html#view
      */
-    public function view(string $component = null, array|Arrayable|DataObject $properties = []): Factory
+    public function view(?string $component = null, array|Arrayable|DataObject $properties = []): Factory
     {
         return view($component, $properties);
     }
@@ -79,7 +79,7 @@ trait ForwardsToHybridlyHelpers
      *
      * @see https://hybridly.dev/api/laravel/hybridly.html#is-hybrid
      */
-    public function isHybrid(Request $request = null): bool
+    public function isHybrid(?Request $request = null): bool
     {
         return is_hybrid($request);
     }
@@ -89,7 +89,7 @@ trait ForwardsToHybridlyHelpers
      *
      * @see https://hybridly.dev/api/laravel/hybridly.html#is-partial
      */
-    public function isPartial(Request $request = null): bool
+    public function isPartial(?Request $request = null): bool
     {
         return is_partial($request);
     }

--- a/packages/laravel/src/Concerns/HasRootView.php
+++ b/packages/laravel/src/Concerns/HasRootView.php
@@ -11,7 +11,7 @@ trait HasRootView
     /**
      * Sets the root view for the next response.
      */
-    public function setRootView(\Closure|string $rootView = null): static
+    public function setRootView(null|\Closure|string $rootView = null): static
     {
         $this->rootView = $rootView;
 

--- a/packages/laravel/src/Concerns/HasSharedProperties.php
+++ b/packages/laravel/src/Concerns/HasSharedProperties.php
@@ -31,7 +31,7 @@ trait HasSharedProperties
     /**
      * Gets data being shared to every response.
      */
-    public function shared(string $key = null, mixed $default = null): mixed
+    public function shared(?string $key = null, mixed $default = null): mixed
     {
         if ($key) {
             return data_get($this->sharedProperties, $key, value($default));

--- a/packages/laravel/src/Testing/TestResponseMacros.php
+++ b/packages/laravel/src/Testing/TestResponseMacros.php
@@ -51,7 +51,7 @@ class TestResponseMacros
 
     public function assertHybrid(): Closure
     {
-        return function (Closure $callback = null): TestResponse {
+        return function (?Closure $callback = null): TestResponse {
             /** @var TestResponse $this */
             $assert = Assertable::fromTestResponse($this);
 
@@ -70,7 +70,7 @@ class TestResponseMacros
      */
     public function assertHasHybridProperty(): Closure
     {
-        return function (string $key, $length = null, \Closure $callback = null): TestResponse {
+        return function (string $key, $length = null, ?\Closure $callback = null): TestResponse {
             /** @var TestResponse $this */
             Assertable::fromTestResponse($this)->has('view.properties.' . $key, $length, $callback);
 
@@ -83,7 +83,7 @@ class TestResponseMacros
      */
     public function assertMissingHybridProperty(): Closure
     {
-        return function (string $key, $length = null, \Closure $callback = null): TestResponse {
+        return function (string $key, $length = null, ?\Closure $callback = null): TestResponse {
             /** @var TestResponse $this */
             Assertable::fromTestResponse($this)->missing('view.properties.' . $key, $length, $callback);
 
@@ -148,7 +148,7 @@ class TestResponseMacros
      */
     public function assertHybridDialog(): Closure
     {
-        return function (array $properties = null, string $view = null, string $baseUrl = null, string $redirectUrl = null): TestResponse {
+        return function (?array $properties = null, ?string $view = null, ?string $baseUrl = null, ?string $redirectUrl = null): TestResponse {
             /** @var TestResponse $this */
             Assertable::fromTestResponse($this)->assertDialog($properties, $view, $baseUrl, $redirectUrl);
 


### PR DESCRIPTION
Fixes:
```
PHP Deprecated:  {closure:Hybridly\Testing\TestResponseMacros::assertHybrid():54}(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Testing/TestResponseMacros.php on line 54
PHP Deprecated:  {closure:Hybridly\Testing\TestResponseMacros::assertHasHybridProperty():73}(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Testing/TestResponseMacros.php on line 73
PHP Deprecated:  {closure:Hybridly\Testing\TestResponseMacros::assertMissingHybridProperty():86}(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Testing/TestResponseMacros.php on line 86
PHP Deprecated:  {closure:Hybridly\Testing\TestResponseMacros::assertHybridDialog():151}(): Implicitly marking parameter $properties as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Testing/TestResponseMacros.php on line 151
PHP Deprecated:  {closure:Hybridly\Testing\TestResponseMacros::assertHybridDialog():151}(): Implicitly marking parameter $view as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Testing/TestResponseMacros.php on line 151
PHP Deprecated:  {closure:Hybridly\Testing\TestResponseMacros::assertHybridDialog():151}(): Implicitly marking parameter $baseUrl as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Testing/TestResponseMacros.php on line 151
PHP Deprecated:  {closure:Hybridly\Testing\TestResponseMacros::assertHybridDialog():151}(): Implicitly marking parameter $redirectUrl as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Testing/TestResponseMacros.php on line 151
PHP Deprecated:  Hybridly\Concerns\ForwardsToHybridlyHelpers::view(): Implicitly marking parameter $component as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Concerns/ForwardsToHybridlyHelpers.php on line 29
PHP Deprecated:  Hybridly\Concerns\ForwardsToHybridlyHelpers::isHybrid(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Concerns/ForwardsToHybridlyHelpers.php on line 82
PHP Deprecated:  Hybridly\Concerns\ForwardsToHybridlyHelpers::isPartial(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Concerns/ForwardsToHybridlyHelpers.php on line 92
PHP Deprecated:  Hybridly\Concerns\HasRootView::setRootView(): Implicitly marking parameter $rootView as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Concerns/HasRootView.php on line 14
PHP Deprecated:  Hybridly\Concerns\HasSharedProperties::shared(): Implicitly marking parameter $key as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Concerns/HasSharedProperties.php on line 34
PHP Deprecated:  Hybridly\Commands\I18nCommand::getTranslations(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Commands/I18nCommand.php on line 89
PHP Deprecated:  Hybridly\Commands\I18nCommand::getTranslationsAsJson(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Commands/I18nCommand.php on line 103
PHP Deprecated:  Hybridly\Commands\I18nCommand::getLocalePath(): Implicitly marking parameter $locale as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Commands/I18nCommand.php on line 138
PHP Deprecated:  Hybridly\Commands\I18nCommand::writeSuccess(): Implicitly marking parameter $locale as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/hybridly/laravel/src/Commands/I18nCommand.php on line 197
```