### PR TITLE
fix(vue): make `useQueryParameters` update after every navigation

### DIFF
--- a/packages/vue/src/composables/query-parameters.ts
+++ b/packages/vue/src/composables/query-parameters.ts
@@ -24,7 +24,7 @@ export function useQueryParameters<T extends Record<string, any> = Record<string
 	}
 
 	updateState()
-	registerHook('after', updateState)
+	registerHook('navigated', updateState)
 
 	return state as T
 }


### PR DESCRIPTION
Fixes #197 

The `after` hook only fires on a real request while the `navigated` hook fires for any hybrid navigation