### PR TITLE
fix: router.local() loses all existing properties

### DIFF
--- a/packages/core/src/router/router.ts
+++ b/packages/core/src/router/router.ts
@@ -519,7 +519,7 @@ export async function performLocalNavigation(targetUrl: UrlResolvable, options?:
 			url,
 			view: {
 				component: options?.component ?? context.view.component,
-				properties: options?.properties ?? {},
+				properties: options?.properties ?? context.view.properties,
 				deferred: [],
 			},
 		},


### PR DESCRIPTION
By default since router.local stays on the component it makes little sense to not keep existing properties
